### PR TITLE
Mergertree converter

### DIFF
--- a/src/core_allvars.h
+++ b/src/core_allvars.h
@@ -36,6 +36,7 @@ enum Valid_OutputFormats
     /* The number of output formats supported by sage */
     sage_binary = 0, /* will be deprecated after version 1 release*/
     sage_hdf5 = 1,
+    lhalo_binary_output = 2, /* special functionality to convert *any* supported input mergertree into a lhalo-binary format */
     num_output_format_types
 };
 

--- a/src/core_read_parameter_file.c
+++ b/src/core_read_parameter_file.c
@@ -446,10 +446,10 @@ int read_parameter_file(const char *fname, struct params *run_params)
     }
 #endif
 
-    const char format_names[][MAXTAGLEN] = {"sage_binary", "sage_hdf5"};
-    const enum Valid_OutputFormats format_enums[] = {sage_binary, sage_hdf5};
+    const char format_names[][MAXTAGLEN] = {"sage_binary", "sage_hdf5", "lhalo_binary_output"};
+    const enum Valid_OutputFormats format_enums[] = {sage_binary, sage_hdf5, lhalo_binary_output};
     const int nvalid_format_types  = sizeof(format_names)/(MAXTAGLEN*sizeof(char));
-    XRETURN(nvalid_format_types == 2, EXIT_FAILURE, "nvalid_format_types = %d should have been 2\n", nvalid_format_types);
+    XRETURN(nvalid_format_types == 3, EXIT_FAILURE, "nvalid_format_types = %d should have been 3\n", nvalid_format_types);
     CHECK_VALID_ENUM_IN_PARAM_FILE(OutputFormat, nvalid_format_types, format_names, format_enums, my_outputformat);
 
     /* Check that the way forests are distributed over (MPI) tasks is valid */

--- a/src/io/read_tree_consistentrees_ascii.c
+++ b/src/io/read_tree_consistentrees_ascii.c
@@ -217,6 +217,10 @@ int setup_forests_io_ctrees(struct forest_info *forests_info, const int ThisTask
     /*MS: 23/9/2019 Fix up the normalisation to make the volume in [0.0, 1.0] (the previous step adds 1.0 per file
       -> the sum should be NumSimulationTreeFiles) */
     forests_info->frac_volume_processed /= (double) run_params->NumSimulationTreeFiles;
+    if(forests_info->frac_volume_processed > 1.0) {
+        fprintf(stderr,"Warning: Fraction of simulation volume  was > 1.0, *clamping* that to 1.0. (fraction - 1.0) = %g\n", forests_info->frac_volume_processed - 1.0);
+        forests_info->frac_volume_processed = 1.0;
+    }
 
     ctr->numfiles = files_fd.numfiles;
     ctr->open_fds = mymalloc(ctr->numfiles * sizeof(ctr->open_fds[0]));

--- a/src/main.c
+++ b/src/main.c
@@ -19,7 +19,7 @@ int main(int argc, char **argv)
     MPI_Comm_size(MPI_COMM_WORLD, &NTasks);
 #endif
 
-    if(argc < 2) {
+    if(argc != 2) {
         fprintf(stderr, "\n  usage: %s <parameterfile>\n\n", argv[0]);
 #ifdef MPI
         MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
@@ -28,40 +28,9 @@ int main(int argc, char **argv)
         return EXIT_FAILURE;
     }
 
-    void *run_params;
-    int status = EXIT_FAILURE;
-    if(argc == 3) {
-        int processing_flag = atoi(argv[2]);
-        /* This (seemingly) odd choice is to reduce accidental
-        usage + keeping the same restartflag value used in Gadget4
-        to generate the LHaloTree mergertrees - MS 11/06/2022 */
-        const int convert_to_lhalo_flag = 8;
-        if(processing_flag != convert_to_lhalo_flag) {
-            fprintf(stderr,"\n If you want to use sage to convert "
-                            "supported mergertrees into LHaloTree "
-                            "binary format, please supply %d as the "
-                            "second command-line parameter (after the "
-                            "name of the parameter file)\n", convert_to_lhalo_flag);
-#ifdef MPI
-            MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
-            MPI_Finalize();
-#endif
-            return EXIT_FAILURE;
-        }
-        status = convert_trees_to_lhalo(ThisTask, NTasks, argv[1], &run_params);
-        if(status != EXIT_SUCCESS) {
-            goto err;
-        }
-#ifdef MPI
-        MPI_Finalize();
-#endif
-        return EXIT_SUCCESS;
-    }
-
-    /* If we are here, then we need to run the SAGE model */
-
     /* initialize sage (read parameter file, setup units, read cooling tables etc) */
-    status = run_sage(ThisTask, NTasks, argv[1], &run_params);
+    void *run_params;
+    int status = run_sage(ThisTask, NTasks, argv[1], &run_params);
     if(status != EXIT_SUCCESS) {
         goto err;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -19,8 +19,8 @@ int main(int argc, char **argv)
     MPI_Comm_size(MPI_COMM_WORLD, &NTasks);
 #endif
 
-    if(argc != 2) {
-        fprintf(stderr, "\n  usage: sage <parameterfile>\n\n");
+    if(argc < 2) {
+        fprintf(stderr, "\n  usage: %s <parameterfile>\n\n", argv[0]);
 #ifdef MPI
         MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
         MPI_Finalize();
@@ -28,13 +28,43 @@ int main(int argc, char **argv)
         return EXIT_FAILURE;
     }
 
-    /* initialize sage (read parameter file, setup units, read cooling tables etc) */
     void *run_params;
-    int status = run_sage(ThisTask, NTasks, argv[1], &run_params);
+    int status = EXIT_FAILURE;
+    if(argc == 3) {
+        int processing_flag = atoi(argv[2]);
+        /* This (seemingly) odd choice is to reduce accidental
+        usage + keeping the same restartflag value used in Gadget4
+        to generate the LHaloTree mergertrees - MS 11/06/2022 */
+        const int convert_to_lhalo_flag = 8;
+        if(processing_flag != convert_to_lhalo_flag) {
+            fprintf(stderr,"\n If you want to use sage to convert "
+                            "supported mergertrees into LHaloTree "
+                            "binary format, please supply %d as the "
+                            "second command-line parameter (after the "
+                            "name of the parameter file)\n", convert_to_lhalo_flag);
+#ifdef MPI
+            MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+            MPI_Finalize();
+#endif
+            return EXIT_FAILURE;
+        }
+        status = convert_trees_to_lhalo(ThisTask, NTasks, argv[1], &run_params);
+        if(status != EXIT_SUCCESS) {
+            goto err;
+        }
+#ifdef MPI
+        MPI_Finalize();
+#endif
+        return EXIT_SUCCESS;
+    }
+
+    /* If we are here, then we need to run the SAGE model */
+
+    /* initialize sage (read parameter file, setup units, read cooling tables etc) */
+    status = run_sage(ThisTask, NTasks, argv[1], &run_params);
     if(status != EXIT_SUCCESS) {
         goto err;
     }
-
 
 #ifdef MPI
     // Wait until all tasks are done before we do final tasks/checks.
@@ -52,7 +82,7 @@ int main(int argc, char **argv)
 #endif
     return EXIT_SUCCESS;
 
- err:
+err:
 #ifdef MPI
     MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
     MPI_Finalize();

--- a/src/sage.c
+++ b/src/sage.c
@@ -5,6 +5,9 @@
 #include <sys/stat.h>
 #include <sys/time.h>
 
+#include <fcntl.h> //open/close
+#include <unistd.h> //pwrite
+
 #ifdef MPI
 #include <mpi.h>
 #endif
@@ -57,11 +60,6 @@ int run_sage(const int ThisTask, const int NTasks, const char *param_file, void 
     forest_info.totnforests = 0;
     forest_info.nforests_this_task = 0;
 
-    struct save_info save_info;
-
-    char buffer[4*MAX_STRING_LEN + 1];
-    snprintf(buffer, 4*MAX_STRING_LEN, "%s/%s_z%1.3f_%d", run_params->OutputDir, run_params->FileNameGalaxies, run_params->ZZ[run_params->ListOutputSnaps[0]], ThisTask);
-
     /* setup the forests reading, and then distribute the forests over the Ntasks */
     status = setup_forests_io(run_params, &forest_info, ThisTask, NTasks);
     if(status != EXIT_SUCCESS) {
@@ -92,6 +90,7 @@ int run_sage(const int ThisTask, const int NTasks, const char *param_file, void 
 
     const int64_t Nforests = forest_info.nforests_this_task;
 
+    struct save_info save_info;
     // Allocate memory for the total number of galaxies for each output snapshot (across all forests).
     // Calloc because we start with no galaxies.
     save_info.tot_ngals = mycalloc(run_params->NumSnapOutputs, sizeof(*(save_info.tot_ngals)));
@@ -352,6 +351,178 @@ int32_t sage_per_forest(const int64_t forestnr, struct save_info *save_info,
     myfree(HaloGal);
     myfree(HaloAux);
     myfree(Halo);
+
+    return EXIT_SUCCESS;
+}
+
+int convert_trees_to_lhalo(const int ThisTask, const int NTasks, const char *param_file, void **params)
+{
+    struct params *run_params = malloc(sizeof(*run_params));
+    if(run_params == NULL) {
+        fprintf(stderr,"Error: On ThisTask = %d (out of NTasks = %d), failed to allocate memory "\
+                "for the C-struct to to hold the run params. Requested size = %zu bytes...returning\n",
+                ThisTask, NTasks, sizeof(*run_params));
+        return MALLOC_FAILURE;
+    }
+    run_params->ThisTask = ThisTask;
+    run_params->NTasks = NTasks;
+    *params = run_params;
+
+    int32_t status = read_parameter_file(param_file, run_params);
+    if(status != EXIT_SUCCESS) {
+        return status;
+    }
+
+    /* Now start the model */
+    struct timeval tstart;
+    gettimeofday(&tstart, NULL);
+
+    struct forest_info forest_info;
+    memset(&forest_info, 0, sizeof(struct forest_info));
+    forest_info.totnforests = 0;
+    forest_info.nforests_this_task = 0;
+
+    // char buffer[4*MAX_STRING_LEN + 1];
+    // snprintf(buffer, 4*MAX_STRING_LEN, "%s/%s_z%1.3f_%d", run_params->OutputDir, run_params->FileNameGalaxies, run_params->ZZ[run_params->ListOutputSnaps[0]], ThisTask);
+
+    /* setup the forests reading, and then distribute the forests over the Ntasks */
+    status = setup_forests_io(run_params, &forest_info, ThisTask, NTasks);
+    if(status != EXIT_SUCCESS) {
+        return status;
+    }
+
+    if(forest_info.totnforests < 0 || forest_info.nforests_this_task < 0) {
+        fprintf(stderr,"Error: Bug in code totnforests = %"PRId64" and nforests (on this task) = %"PRId64" should both be at least 0\n",
+                forest_info.totnforests, forest_info.nforests_this_task);
+        return EXIT_FAILURE;
+    }
+
+    if(forest_info.nforests_this_task > INT_MAX) {
+        fprintf(stderr,"Error: Can not correctly cast nforests (on this task) = %"PRId64" to fit within a 4-byte integer (as required by the LHaloTree binary format specification). Converting fewer input files or adding more parallel cores (currently using %d cores) will help alleviate the issue\n",
+                forest_info.nforests_this_task, NTasks);
+        return EXIT_FAILURE;
+    }
+
+    const int64_t nforests_this_task = forest_info.nforests_this_task;
+    int64_t totnhalos = 0;
+
+#define WRITE_AND_CHECK(fd, var, nbytes_to_write)                                   \
+    do {                                                                            \
+        ssize_t bytes_written = write(fd, &var, nbytes_to_write);                   \
+        if(bytes_written != (ssize_t) nbytes_to_write) {                            \
+            fprintf(stderr,"Error: Wrote %zd bytes instead of "                     \
+                            "the required %llu bytes\n",                            \
+                            bytes_written, (unsigned long long) nbytes_to_write);   \
+            perror(NULL);                                                           \
+            return EXIT_FAILURE;                                                    \
+        }                                                                           \
+    } while (0)
+
+#define PWRITE_64BIT_TO_32BIT(fd, var, offset, kind_of_var)             \
+    do {                                                                \
+        if(sizeof(var) != sizeof(int64_t)) {                            \
+            fprintf(stderr,"Error: Bug in code - this is only "         \
+            "meant to work on 64 bit integers\n");                      \
+            return EXIT_FAILURE;                                        \
+        }                                                               \
+        if(var > INT_MAX) {                                             \
+            fprintf(stderr,"Error: Number of halos = %"PRId64" does "   \
+                            "not fit inside 32 bits "                   \
+                            "(context = %s)\n", var, kind_of_var);      \
+            return EXIT_FAILURE;                                        \
+        }                                                               \
+        const int32_t var_int32 = (int32_t) var;                        \
+        const ssize_t bytes_written = pwrite(fd, &var_int32,            \
+                                             sizeof(var_int32), offset);\
+        if(bytes_written != sizeof(var_int32)) {                        \
+            fprintf(stderr,"Error: Wrote %zd bytes instead of "         \
+                        "the required %zu bytes\n",                     \
+                        bytes_written, sizeof(var_int32));              \
+            perror(NULL);                                               \
+            return EXIT_FAILURE;                                        \
+        }                                                               \
+    } while (0)
+
+    char buffer[3*MAX_STRING_LEN + 1];
+    snprintf(buffer, 3*MAX_STRING_LEN, "%s%s.%d", run_params->OutputDir,
+             run_params->FileNameGalaxies, ThisTask);
+    int fd = open(buffer, O_CREAT|O_TRUNC|O_WRONLY, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);
+    XRETURN(fd > 0, EXIT_FAILURE, "Error: Could not open filename = %s\n", buffer);
+
+    //PWRITE does not update the file offset -> will need to be adjusted manually
+    PWRITE_64BIT_TO_32BIT(fd, nforests_this_task, 0, "total number of forests");
+    PWRITE_64BIT_TO_32BIT(fd, totnhalos, 4, "total number of halos (initial, set to 0)");
+
+    const off_t nhalos_per_forest_bytes = sizeof(int32_t)*nforests_this_task;
+    //since the previous writes for totnforests and totnhalos were with pwrite
+    //we need to adjust the file offset for those two 32-bit integers
+    const off_t halo_data_start_offset = 4 + 4 + nhalos_per_forest_bytes;
+
+    XRETURN(lseek(fd, halo_data_start_offset, SEEK_SET) == halo_data_start_offset,
+            EXIT_FAILURE,
+            "Error: Could not seek to %llu bytes to write the "
+            "start of the halo data from the first forest",
+            halo_data_start_offset);
+
+    run_params->interrupted = 0;
+#ifdef VERBOSE
+    if(ThisTask == 0) {
+        init_my_progressbar(stdout, nforests_this_task, &(run_params->interrupted));
+#ifdef MPI
+        if(NTasks > 1) {
+            fprintf(stderr, "Please Note: The progress bar is not precisely reliable in MPI. "
+                    "It should be used as a general indicator only.\n");
+        }
+#endif
+    }
+#endif
+
+    /* simulation merger-tree data */
+    struct halo_data *Halo = NULL;
+    for(int64_t forestnr=0; forestnr < nforests_this_task; forestnr++) {
+#ifdef VERBOSE
+        if(ThisTask == 0) {
+            my_progressbar(stdout, forestnr, &(run_params->interrupted));
+            fflush(stdout);
+        }
+#endif
+
+        /* nhalos is meaning-less for consistent-trees until *AFTER* the forest has been loaded */
+        const int64_t nhalos = load_forest(run_params, forestnr, &Halo, &forest_info);
+        if(nhalos < 0) {
+            fprintf(stderr,"Error during loading forestnum =  %"PRId64"...exiting\n", forestnr);
+            return nhalos;
+        }
+        WRITE_AND_CHECK(fd, *Halo, sizeof(struct halo_data)*nhalos);//write updates the file offset
+
+        const off_t nh_per_tree_offset = sizeof(int32_t) + sizeof(int32_t) + forestnr * sizeof(int32_t);
+        PWRITE_64BIT_TO_32BIT(fd, nhalos, nh_per_tree_offset, "nhalos per tree");//pwrite does not update file offset
+
+        myfree(Halo);
+        totnhalos += nhalos;
+    }
+
+    /* Check that totnhalos fits within a 4 byte integer and write to the file */
+    PWRITE_64BIT_TO_32BIT(fd, totnhalos, 4, "total number of halos in file");
+
+    XRETURN(close(fd) == 0, EXIT_FAILURE, "Error while closing the output binary file");
+
+    /* sage is done running -> do the cleanup */
+    cleanup_forests_io(run_params->TreeType, &forest_info);
+
+#ifdef VERBOSE
+    if(ThisTask == 0) {
+        finish_myprogressbar(stdout, &(run_params->interrupted));
+    }
+
+    struct timeval tend;
+    gettimeofday(&tend, NULL);
+    char *time_string = get_time_string(tstart, tend);
+    fprintf(stderr,"ThisTask = %d done processing all forests assigned. Time taken = %s\n", ThisTask, time_string);
+    free(time_string);
+    fflush(stdout);
+#endif
+    free(run_params);
 
     return EXIT_SUCCESS;
 }

--- a/src/sage.c
+++ b/src/sage.c
@@ -462,7 +462,7 @@ int convert_trees_to_lhalo(const int ThisTask, const int NTasks, const char *par
             EXIT_FAILURE,
             "Error: Could not seek to %llu bytes to write the "
             "start of the halo data from the first forest",
-            halo_data_start_offset);
+            (unsigned long long) halo_data_start_offset);
 
     run_params->interrupted = 0;
 #ifdef VERBOSE

--- a/src/sage.h
+++ b/src/sage.h
@@ -14,7 +14,10 @@ extern "C" {
 
     /* API for sage */
     extern int run_sage(const int ThisTask, const int NTasks, const char *param_file, void **params);
-    extern int finalize_sage(void *run_params);
+    extern int finalize_sage(void *params);
+
+    /* API for converting supported mergertre formats to the Millennium (LHaloTree) binary format */
+    extern int convert_trees_to_lhalo(const int ThisTask, const int NTasks, const char *param_file, void **params);
 
 #ifdef __cplusplus
 }

--- a/src/sage.h
+++ b/src/sage.h
@@ -16,9 +16,6 @@ extern "C" {
     extern int run_sage(const int ThisTask, const int NTasks, const char *param_file, void **params);
     extern int finalize_sage(void *params);
 
-    /* API for converting supported mergertre formats to the Millennium (LHaloTree) binary format */
-    extern int convert_trees_to_lhalo(const int ThisTask, const int NTasks, const char *param_file, void **params);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Can be used to convert *any* supported **input** mergertree formats into the `lhalo-binary` format (which can be ingested by the likes of DarkSage and DustySage)