### PR TITLE
Gadget4 Mergertree format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           conda create -q --yes -n test python=${{ matrix.python-version }}
           conda activate test
-          conda install -c conda-forge numpy=${{ matrix.numpy-version }} hdf5 gsl
+          conda install -q -c conda-forge numpy=${{ matrix.numpy-version }} hdf5 gsl
           python -m pip install -r requirements.txt
       - name: Display PATH, compiler, python
         shell: bash -l {0}

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ USE-HDF5 := yes # set this if you want to read in hdf5 trees (requires hdf5 libr
 #MEM-CHECK = yes # Set this if you want to check sanitize pointers/memory addresses. Slowdown of ~2x is expected.
 				 # Note: This only works with gcc
 
+USE-BUFFERED-WRITE := yes # Set this to create binary output in chunks (typically has better performance)
+
 MAKE-SHARED-LIB := yes # Define this to any value if you want to create a shared library (otherwise a static library is created)
 MAKE-VERBOSE := yes # define this for info messages, otherwise all info messages are disabled (*error* messages are *always* printed)
 
@@ -26,7 +28,7 @@ LIBSRC :=  sage.c core_read_parameter_file.c core_init.c core_io_tree.c \
            core_tree_utils.c model_infall.c model_cooling_heating.c model_starformation_and_feedback.c \
            model_disk_instability.c model_reincorporation.c model_mergers.c model_misc.c \
            io/read_tree_lhalo_binary.c io/read_tree_consistentrees_ascii.c io/ctrees_utils.c \
-	   io/save_gals_binary.c io/forest_utils.c
+	       io/save_gals_binary.c io/forest_utils.c io/buffered_io.c
 
 LIBINCL := $(LIBSRC:.c=.h)
 LIBINCL += io/parse_ctrees.h
@@ -146,6 +148,9 @@ ifeq ($(DO_CHECKS), 1)
   CCFLAGS += $(GSL_INCL)
   LIBFLAGS += $(GSL_LIBS)
 
+  ifdef USE-BUFFERED-WRITE
+    CCFLAGS += -DUSE_BUFFERED_WRITE
+  endif
 
   ifdef USE-HDF5
     ifndef HDF5_DIR

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ endif
 # if condition (for DO_CHECKS); otherwise `make clean` will not
 # clean the H5_OBJS
 H5_SRC := io/read_tree_lhalo_hdf5.c io/save_gals_hdf5.c io/read_tree_genesis_hdf5.c io/hdf5_read_utils.c \
-          io/read_tree_consistentrees_hdf5.c
+          io/read_tree_consistentrees_hdf5.c io/read_tree_gadget4_hdf5.c
 
 H5_INCL := $(H5_SRC:.c=.h)
 H5_OBJS := $(H5_SRC:.c=.o)
@@ -243,7 +243,7 @@ ifeq ($(DO_CHECKS), 1)
   endif
 
   CCFLAGS += -g -Wextra -Wshadow -Wall -Wno-unused-local-typedefs # and more warning flags
-  LIBFLAGS   +=   -lm
+  LIBFLAGS +=   -lm
 
 else
   # something like `make clean` is in effect -> need to also remove the HDF5 objects

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ LIBSRC :=  sage.c core_read_parameter_file.c core_init.c core_io_tree.c \
            core_tree_utils.c model_infall.c model_cooling_heating.c model_starformation_and_feedback.c \
            model_disk_instability.c model_reincorporation.c model_mergers.c model_misc.c \
            io/read_tree_lhalo_binary.c io/read_tree_consistentrees_ascii.c io/ctrees_utils.c \
-      	   io/save_gals_binary.c io/forest_utils.c
+	   io/save_gals_binary.c io/forest_utils.c
 
 LIBINCL := $(LIBSRC:.c=.h)
 LIBINCL += io/parse_ctrees.h
@@ -126,7 +126,7 @@ ifeq ($(DO_CHECKS), 1)
   endif
 
   ifeq ($(ON_CI), true)
-	# If running on CI, fail if any warnings are generated when Making.
+  ## If running on CI, fail if any warnings are generated when Making.
     CCFLAGS += -Werror
   endif
   ## end of checking is CC

--- a/src/core_allvars.h
+++ b/src/core_allvars.h
@@ -28,8 +28,20 @@ enum Valid_TreeTypes
     genesis_hdf5 = 2,
     consistent_trees_ascii = 3,
     consistent_trees_hdf5 = 4,
+    gadget4_hdf5 = 5,
     num_tree_types
 };
+
+/* Struct for making hdf5 file reading a bit easier */
+struct HDF5_METADATA_NAMES
+{
+    char name_NTrees[MAX_STRING_LEN];
+    char name_totNHalos[MAX_STRING_LEN];
+    char name_TreeNHalos[MAX_STRING_LEN];
+    char name_ParticleMass[MAX_STRING_LEN];
+    char name_NumSimulationTreeFiles[MAX_STRING_LEN];
+};
+
 
 enum Valid_OutputFormats
 {
@@ -171,7 +183,7 @@ struct lhalotree_info {
     int64_t nforests;/* number of forests to process */
 
     /* lhalotree format only has int32_t for nhalos per forest */
-    int32_t *nhalos_per_forest;/* number of halos to read, nforests elements */
+    int64_t *nhalos_per_forest;/* number of halos to read, nforests elements */
 
     union {
         int *fd;/* the file descriptor for each forest (i.e., which file descriptor to read this forest from) nforests elements*/
@@ -275,6 +287,49 @@ struct ctrees_h5_info {
     int32_t end_filenum; /* the last file processed on this task (inclusive) */
 };
 
+struct gadget4_info {
+    int64_t nforests;/* number of forests to process on this task, scalar */
+
+    // int64_t start_forestnum_first_file;/* the forest number (file-local) that is the first forest assigned to this task, scalar*/
+    int64_t *nhalos_per_forest; /* number of halos per forest, nforests elements*/
+
+    int32_t numfiles;/* number of unique files being processed by this task,  must be >=1 and <= lastfile - firstfile + 1 */
+    hid_t *open_h5_fds;/* contains open HDF5 file descriptors,  contains numfiles elements */
+
+    // Unlike all the other mergertree formats, in the Gadget4 mergertree format, a single forest
+    // can be spread over multiple files (potentially >> 1). Therefore, we need to know the range of files
+    // that the forest is spread across. The loop over files should go from
+    // ``[ start_fd_index_for_forest[iforest], end_fd_index_for_forests[iforest] ]`` (inclusive).
+    // Within the loop, the reading for the first file needs to start at ``offset_in_first_file_for_forests[iforest]``
+    // The number of halos that should be read in a file is ``min(halos_left_in_file, num_halos_left_to_read_in_forest )``
+    //      ii) end file for forest -> read min()
+
+    int32_t *start_h5_fd_index; /* contains the  index into open_h5_fds (starting) HDF5 file descriptor for each forest
+                                    filenr-based indexing into open_h5_fds -> i.e., assumes that open_h5_fds can
+                                    be indexed by (at least) [start_filenum, end_filenum] , nforests elements */
+
+    int16_t *num_files_per_forest; /* contains the number of files that the forest is split across (used to index the HDF5 file descriptor for each forest), nforests elements */
+    int32_t **nhalos_per_file_per_forest; /* irregular 2-D matrix, containing the number of halos within *each* file that this forest is spread over,
+                                            dimension is at least [1, nforests], and set to [num_files_for_forests[iforest], nforests]
+                                            loading code for `iforest` would look like:
+
+                                                const int32_t numfiles = num_files_for_forests[iforest];
+                                                int32_t h5_fd_index = start_h5_fd_index[iforest];
+                                                int64_t start_offset = offset_in_first_file_for_forests[iforest];
+                                                for(int32_t i=0;i<numfiles;i++) {
+                                                    const int64_t numhalos_thisfile = nhalos_per_file_per_forest[i][iforest];
+                                                    assert(numhalos_thisfile > 0);
+                                                    hid_t hfd = open_h5_fds[h5_fd_index];
+                                                    assert(hfd > 0);
+                                                    READ_PARTIAL_HALOS_HDF5(hfd, start_offset, numhalos_thisfile);
+                                                    h5_fd_index++;
+                                                    start_offset = 0;
+                                                }
+                                            */
+    int64_t *offset_in_nhalos_first_file_for_forests; /* offset counted in nhalos contained in all preceeding forests,
+                                                        where to start reading the forest in the first files, nforests elements */
+    // int64_t *offset_in_forests_first_file_for_forests; /* offset counted as the number of preceeding forests in that first file, nforests elements */
+};
 #endif
 
 struct forest_info {
@@ -285,19 +340,30 @@ struct forest_info {
 #ifdef HDF5
         struct genesis_info gen;
         struct ctrees_h5_info ctr_h5;
+        struct gadget4_info gadget4;
 #endif
     };
+
+    /* Run-level quantities */
     int64_t totnforests;  // Total number of forests across **all** input tree files.
-    int64_t nforests_this_task; // Total number of forests processed by **this** task.
+    int64_t totnhalos; //Total number of halos across **all** input tree files (if it can be calculated ahead of time, otherwise set to 0 e.g., in case of Consistent-Trees ascii)
     double frac_volume_processed; // Fraction of the simulation volume processed by **this** task.
     // We assume that each of the input tree files span the same volume. Hence by summing the
     // number of trees processed by each task from each file, we can determine the
     // fraction of the simulation volume that this task processes.  We weight this summation by the
     // number of trees in each file because some files may have more/less trees whilst still spanning the
     // same volume (e.g., a void would contain few trees whilst a dense knot would contain many).
-    int32_t firstfile;//The first file processed in this run
-    int32_t lastfile;//The last file processed in this run
-    int32_t *FileNr; // The file number that each forest needs to be read from.
+    int32_t firstfile;//The first file processed in this run (i.e., over all tasks)
+    int32_t lastfile;//The last file processed in this run (i.e., over all tasks)
+
+    /* Task level quantities -> unique for each task */
+    int64_t nforests_this_task; // Total number of forests processed by **this** task.
+    int64_t nhalos_this_task;// Total number of halos to be processed by **this** task (if it can be calculated ahead of time, otherwise set to 0 e.g., in case of Consistent-Trees ascii)
+
+    /* Forest-level quantities (per task) */
+    int32_t *FileNr; // The file number that each forest needs to be read from. For formats where an individual tree may be
+                     // split across multiple files (e.g., Gadget4), this field contains the starting file number (i.e., where the
+                    // first halos within the tree are to be found)
     int64_t *original_treenr; // The (file-local) tree number from the original tree files.
                               // Necessary because Task N's "Tree 0" could start at the middle of a file.
 };

--- a/src/core_io_tree.c
+++ b/src/core_io_tree.c
@@ -19,6 +19,7 @@
 #include "io/read_tree_lhalo_hdf5.h"
 #include "io/read_tree_genesis_hdf5.h"
 #include "io/read_tree_consistentrees_hdf5.h"
+#include "io/read_tree_gadget4_hdf5.h"
 #endif
 
 int setup_forests_io(struct params *run_params, struct forest_info *forests_info,
@@ -43,6 +44,10 @@ int setup_forests_io(struct params *run_params, struct forest_info *forests_info
             //MS: 22/07/2021 - Why is firstfile, lastfile still passed even though those could be constructef
             //from run_params (like done within this __FUNCTION__)
             status = setup_forests_io_lht_hdf5(forests_info, ThisTask, NTasks, run_params);
+            break;
+
+        case gadget4_hdf5:
+            status = setup_forests_io_gadget4_hdf5(forests_info, ThisTask, NTasks, run_params);
             break;
 
         case genesis_hdf5:
@@ -103,6 +108,10 @@ void cleanup_forests_io(enum Valid_TreeTypes TreeType, struct forest_info *fores
         cleanup_forests_io_lht_hdf5(forests_info);
         break;
 
+    case gadget4_hdf5:
+        cleanup_forests_io_gadget4_hdf5(forests_info);
+        break;
+
     case genesis_hdf5:
         cleanup_forests_io_genesis_hdf5(forests_info);
         break;
@@ -150,6 +159,10 @@ int64_t load_forest(struct params *run_params, const int64_t forestnr, struct ha
 #ifdef HDF5
     case lhalo_hdf5:
         nhalos = load_forest_lht_hdf5(forestnr, halos, forests_info, run_params->Hubble_h);
+        break;
+
+    case gadget4_hdf5:
+        nhalos = load_forest_gadget4_hdf5(forestnr, halos, forests_info, run_params->Hubble_h);
         break;
 
     case genesis_hdf5:

--- a/src/core_io_tree.c
+++ b/src/core_io_tree.c
@@ -158,11 +158,11 @@ int64_t load_forest(struct params *run_params, const int64_t forestnr, struct ha
 
 #ifdef HDF5
     case lhalo_hdf5:
-        nhalos = load_forest_lht_hdf5(forestnr, halos, forests_info, run_params->Hubble_h);
+        nhalos = load_forest_lht_hdf5(forestnr, halos, forests_info);
         break;
 
     case gadget4_hdf5:
-        nhalos = load_forest_gadget4_hdf5(forestnr, halos, forests_info, run_params->Hubble_h);
+        nhalos = load_forest_gadget4_hdf5(forestnr, halos, forests_info);
         break;
 
     case genesis_hdf5:

--- a/src/core_read_parameter_file.c
+++ b/src/core_read_parameter_file.c
@@ -398,8 +398,10 @@ int read_parameter_file(const char *fname, struct params *run_params)
     run_params->TreeExtension[0] = '\0';
 
     // Check tree type is valid.
-    if (strncmp(my_treetype, "lhalo_hdf5", 511) == 0 ||
-        strncmp(my_treetype, "genesis_hdf5", 511) == 0) {
+    if (strncmp(my_treetype, "lhalo_hdf5", 511)   == 0 ||
+        strncmp(my_treetype, "genesis_hdf5", 511) == 0 ||
+        strncmp(my_treetype, "gadget4_hdf5", 511) == 0
+        ) {
 #ifndef HDF5
         fprintf(stderr, "You have specified to use a HDF5 file but have not compiled with the HDF5 option enabled.\n");
         fprintf(stderr, "Please check your file type and compiler options.\n");
@@ -430,9 +432,11 @@ int read_parameter_file(const char *fname, struct params *run_params)
  }
 
     const char tree_names[][MAXTAGLEN] = {"lhalo_hdf5", "lhalo_binary", "genesis_hdf5",
-                                          "consistent_trees_ascii", "consistent_trees_hdf5"};
+                                          "consistent_trees_ascii", "consistent_trees_hdf5",
+                                          "gadget4_hdf5"};
     const enum Valid_TreeTypes tree_enums[] = {lhalo_hdf5, lhalo_binary, genesis_hdf5,
-                                               consistent_trees_ascii, consistent_trees_hdf5};
+                                               consistent_trees_ascii, consistent_trees_hdf5,
+                                               gadget4_hdf5};
     const int nvalid_tree_types  = sizeof(tree_names)/(MAXTAGLEN*sizeof(char));
     BUILD_BUG_OR_ZERO((nvalid_tree_types == (int) num_tree_types), number_of_tree_types_is_incorrect);
     CHECK_VALID_ENUM_IN_PARAM_FILE(TreeType, nvalid_tree_types, tree_names, tree_enums, my_treetype);

--- a/src/io/buffered_io.c
+++ b/src/io/buffered_io.c
@@ -1,0 +1,168 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h> //for memcpy
+
+/*
+The initial version of this code was generated using ChatGPT as a fun exercise. The instructions
+given were (formatting applied to the following script):
+
+Write C code to write in binary to files using a 4 MB buffer that stores data until the 4 MB limit and then writes out. The code should have 3 functions 
+- a setup function that defines a struct, called "buffered_io" containing these items - 
+    i) number of bytes allocated of type size_t 
+    ii) number of bytes stored of type size_t 
+    iii) file descriptor of the output file of type integer and 
+    iv) the current file offset  of type off_t 
+    v) a void * pointer that holds the data. 
+
+    The setup function is called with the buffer size in bytes of type size_t, the output file description (> 0),  
+    the offset to start writing at (> 0), and a pointer to a struct of type buffered_io (must not be NULL). 
+    The setup function will allocate the buffer (return -1 if malloc fails), and store the file offset and the 
+    file descriptor within the passed struct. The will return EXIT_SUCCESS if no errors are encountered. 
+- a runtime function that is called with two parameters: 
+    i) the number of bytes to write 
+    ii) a void * pointer to the source that contains the data to be written out and 
+    iii) a pointer to the struct buffered_io previously setup. 
+    
+    This function will check whether the buffer is sufficiently large to hold the new set of bytes and will 
+    copy over the bytes from the source pointer if that's the case. After copying the data, the number of bytes 
+    within the bufferd_io struct should be incremented by the number of bytes copied.  If the buffer is not 
+    large enough to hold the new bytes requested, the function will first write out the data in the buffer using pwrite, 
+    and update the offset within the struct buffered_io. After that, the function will increment the offset 
+    within the buffered_io struct with the number of bytes written out, and set the number of bytes within the b
+    ufferd_io struct to 0. Then the function will keep writing out the data from the src pointer  (using pwrite) 
+    until the number of bytes remaining is less than the buffer size allocated. For every pwrite call, the offset 
+    within the buffered_io struct needs to be incremented by the number of bytes successfully written out. Once the 
+    remaining data is less than the buffer max size, then the data should be copied from the source into the 
+    struct buffered_io, and the number of bytes within the bufferd_io struct should be set to the number of bytes copied
+
+- a cleanup function that accepts only a single parameter for a pointer to a struct buffered_io and writes out (using pwrite) 
+    any remaining data in the buffer, and updates the offset and number of bytes correctly. If the write fails, then the 
+    return error from pwrite is returned. Assuming a successful write, the memory is cleared out from the buffer and returns EXIT_SUCCESS
+
+The original version was mostly correct but I had to add a *LOT* of error checking code, improve readability, and make for a consistent
+design across the three helper functions. 
+
+Side-note: The amount of explicit instruction required to generate the code meant I could have written the code in the time it took me to type
+out the instructions. -MS 27th Jul, 2023
+
+*/
+
+
+
+#include "buffered_io.h"
+#include "../core_utils.h" //for mypwrite
+
+
+int setup_buffered_io(struct buffered_io *buf_io, const size_t buffer_size, int output_fd, const off_t start_offset) 
+{
+    /*start_offset can (in theory at least) be negative. off_t is a signed integer (32 or 64-bit, depending on on the compile-time
+    constatnt for FILE_OFFSET_BITS). Therefore, we only check for the two other parameters */
+    if(buffer_size <= 0 || output_fd <= 0) {
+        fprintf(stderr,"Error: In %s> All buffer size = %zd (bytes) and output file descriptor = %d must be greater than 0\n", 
+                      __FUNCTION__, buffer_size, output_fd);
+        return -1;
+    }
+
+    // Allocate memory for the buffer
+    buf_io->buffer = malloc(buffer_size);
+    if (buf_io->buffer == NULL) {
+        fprintf(stderr,"Error: In %s> Could not allocate memory of size %zu bytes for buffered io\n", __FUNCTION__, buffer_size);
+        return -1; // Return -1 if malloc fails
+    }
+
+    // Initialize the buffered_io struct
+    buf_io->bytes_allocated = buffer_size;
+    buf_io->bytes_stored = 0;
+    buf_io->file_descriptor = output_fd;
+    buf_io->current_offset = start_offset;
+
+    return EXIT_SUCCESS;
+}
+
+int write_bufferd_io(struct buffered_io *buf_io, const void *src, size_t num_bytes_to_write)
+{
+    if(buf_io == NULL || src == NULL)  {
+        fprintf(stderr,"Error: In %s> Could not validate input parameters.  buffer pointer address = %p, "
+                       "source pointer address = %p\n",
+                       __FUNCTION__, buf_io, src);
+        return -1;
+    }
+
+    // Check if the buffer has enough space to hold new data
+    if ((buf_io->bytes_stored + num_bytes_to_write) < buf_io->bytes_allocated) {
+        // Copy data to the buffer
+        char* dest = (char*)buf_io->buffer + buf_io->bytes_stored;
+        memcpy(dest, src, num_bytes_to_write);
+
+        // Increment the number of bytes stored in the buffered_io struct
+        buf_io->bytes_stored += num_bytes_to_write;
+        return EXIT_SUCCESS;
+    } 
+    
+    //If we are here, then we are exceeding the allocated buffer size. Therefore, we need
+    //to first write out all the data that exists within the buffer
+    ssize_t bytes_written = mypwrite(buf_io->file_descriptor, buf_io->buffer, buf_io->bytes_stored, buf_io->current_offset);
+    if (bytes_written < 0) {
+        return bytes_written; // Return error if pwrite fails
+    }
+
+    // Update the offset and number of bytes in the buffered_io struct
+    buf_io->current_offset += bytes_written;
+    buf_io->bytes_stored = 0;
+
+    //Now we need to consider the new write request. If the number of bytes to write
+    //exceeds the allocated buffer size, then we should just directly write out all the 
+    //data from the src pointer.
+    if (num_bytes_to_write >= buf_io->bytes_allocated) {
+        const ssize_t new_bytes_written = mypwrite(buf_io->file_descriptor, src, num_bytes_to_write, buf_io->current_offset);
+        if (new_bytes_written < 0) {
+            return new_bytes_written; // Return error if pwrite fails
+        }
+
+        if(new_bytes_written != (ssize_t) num_bytes_to_write) {
+            fprintf(stderr,"Error: In function %s> Expected to write %zd bytes but wrote %zd bytes instead\n", 
+                            __FUNCTION__, num_bytes_to_write, num_bytes_to_write);
+            return -1;
+        }
+
+        // Update the offset and remaining data to write
+        buf_io->current_offset += new_bytes_written;
+        bytes_written += new_bytes_written;
+    } else {
+
+        // Copy the new data to the buffer and increment the number of bytes stored
+        memcpy(buf_io->buffer, src, num_bytes_to_write);
+        buf_io->bytes_stored += num_bytes_to_write;
+    }
+
+    return EXIT_SUCCESS;
+}
+
+int cleanup(struct buffered_io *buf_io) 
+{
+    if(buf_io == NULL) {
+        fprintf(stderr,"Error: In %s> Could not validate input parameters. buffer pointer address = %p", __FUNCTION__, buf_io);
+        return -1;
+    }
+
+    // Write out any remaining data in the buffer
+    ssize_t bytes_written = mypwrite(buf_io->file_descriptor, buf_io->buffer, buf_io->bytes_stored, buf_io->current_offset);
+    if (bytes_written < 0) {
+        fprintf(stderr,"Error: In %s> Could not finalise the file in buffered io\n", __FUNCTION__);
+        perror(NULL);
+        return bytes_written;
+    }
+
+    // Update the offset and number of bytes in the buffered_io struct
+    buf_io->current_offset += bytes_written;
+
+    // Free the memory allocated for the buffer
+    free(buf_io->buffer);
+    buf_io->buffer = NULL;
+    buf_io->bytes_allocated = 0;
+    buf_io->bytes_stored = 0;
+
+    return EXIT_SUCCESS;
+}

--- a/src/io/buffered_io.c
+++ b/src/io/buffered_io.c
@@ -81,7 +81,7 @@ int setup_buffered_io(struct buffered_io *buf_io, const size_t buffer_size, int 
     return EXIT_SUCCESS;
 }
 
-int write_bufferd_io(struct buffered_io *buf_io, const void *src, size_t num_bytes_to_write)
+int write_buffered_io(struct buffered_io *buf_io, const void *src, size_t num_bytes_to_write)
 {
     if(buf_io == NULL || src == NULL)  {
         fprintf(stderr,"Error: In %s> Could not validate input parameters.  buffer pointer address = %p, "

--- a/src/io/buffered_io.c
+++ b/src/io/buffered_io.c
@@ -140,7 +140,7 @@ int write_bufferd_io(struct buffered_io *buf_io, const void *src, size_t num_byt
     return EXIT_SUCCESS;
 }
 
-int cleanup(struct buffered_io *buf_io) 
+int cleanup_buffered_io(struct buffered_io *buf_io) 
 {
     if(buf_io == NULL) {
         fprintf(stderr,"Error: In %s> Could not validate input parameters. buffer pointer address = %p", __FUNCTION__, buf_io);

--- a/src/io/buffered_io.h
+++ b/src/io/buffered_io.h
@@ -13,7 +13,7 @@ struct buffered_io{
 };
 
     extern int setup_buffered_io(struct buffered_io *buf_io, const size_t buffer_size, int output_fd, const off_t start_offset);
-    extern int write_bufferd_io(struct buffered_io *buf_io, const void *src, size_t num_bytes_to_write);
+    extern int write_buffered_io(struct buffered_io *buf_io, const void *src, size_t num_bytes_to_write);
     extern int cleanup_buffered_io(struct buffered_io *buf_io);
 
 #ifdef __cplusplus

--- a/src/io/buffered_io.h
+++ b/src/io/buffered_io.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct buffered_io{
+    size_t bytes_allocated;
+    size_t bytes_stored;
+    int file_descriptor;
+    off_t current_offset;
+    void *buffer;
+};
+
+    extern int setup_buffered_io(struct buffered_io *buf_io, const size_t buffer_size, int output_fd, const off_t start_offset);
+    extern int write_bufferd_io(struct buffered_io *buf_io, const void *src, size_t num_bytes_to_write);
+    extern int cleanup(struct buffered_io *buf_io);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/io/buffered_io.h
+++ b/src/io/buffered_io.h
@@ -14,7 +14,7 @@ struct buffered_io{
 
     extern int setup_buffered_io(struct buffered_io *buf_io, const size_t buffer_size, int output_fd, const off_t start_offset);
     extern int write_bufferd_io(struct buffered_io *buf_io, const void *src, size_t num_bytes_to_write);
-    extern int cleanup(struct buffered_io *buf_io);
+    extern int cleanup_buffered_io(struct buffered_io *buf_io);
 
 #ifdef __cplusplus
 }

--- a/src/io/forest_utils.h
+++ b/src/io/forest_utils.h
@@ -15,6 +15,13 @@ extern "C" {
                                                        const enum Valid_Forest_Distribution_Schemes forest_weighting, const double power_law_index,
                                                        const int NTasks, const int ThisTask, int64_t *nforests_thistask, int64_t *start_forestnum_thistask);
         
+    extern int find_start_and_end_filenum(const int64_t start_forestnum, const int64_t end_forestnum,
+                                          const int64_t *totnforests_per_file, const int64_t totnforests,
+                                          const int firstfile, const int lastfile,
+                                          const int ThisTask, const int NTasks,
+                                          int64_t *num_forests_to_process_per_file, int64_t *start_forestnum_to_process_per_file,
+                                          int *start_file, int *end_file);
+
     
 #ifdef __cplusplus
 }

--- a/src/io/hdf5_read_utils.c
+++ b/src/io/hdf5_read_utils.c
@@ -159,3 +159,37 @@ herr_t read_dataset(hid_t fd, const char *dataset_name, hid_t dataset_id, void *
 
     return (herr_t) EXIT_SUCCESS;
 }
+
+
+int32_t fill_hdf5_metadata_names(struct HDF5_METADATA_NAMES *metadata_names, enum Valid_TreeTypes my_TreeType)
+{
+    switch (my_TreeType) {
+    case lhalo_hdf5:
+        snprintf(metadata_names->name_NTrees, MAX_STRING_LEN - 1, "NtreesPerFile"); // Total number of forests within the file.
+        snprintf(metadata_names->name_totNHalos, MAX_STRING_LEN - 1, "NhalosPerFile"); // Total number of halos within the file.
+        snprintf(metadata_names->name_TreeNHalos, MAX_STRING_LEN - 1, "TreeNHalos"); // Number of halos per forest within the file.
+        snprintf(metadata_names->name_ParticleMass, MAX_STRING_LEN - 1, "ParticleMass");//Particle mass for Dark matter in the sim
+        snprintf(metadata_names->name_NumSimulationTreeFiles, MAX_STRING_LEN - 1, "NumberOfOutputFiles");//Particle mass for Dark matter in the sim
+        return EXIT_SUCCESS;
+
+    case gadget4_hdf5:
+        snprintf(metadata_names->name_NTrees, MAX_STRING_LEN - 1, "Ntrees_ThisFile"); // Total number of forests within the file.
+        snprintf(metadata_names->name_totNHalos, MAX_STRING_LEN - 1, "Nhalos_ThisFile"); // Total number of halos within the file.
+        // snprintf(metadata_names->name_TreeNHalos, MAX_STRING_LEN - 1, "TreeNHalos"); // Number of halos per forest within the file.
+        snprintf(metadata_names->name_ParticleMass, MAX_STRING_LEN - 1, "DOES-NOT-EXIST");//Particle mass for Dark matter in the sim
+        snprintf(metadata_names->name_NumSimulationTreeFiles, MAX_STRING_LEN - 1, "NumFiles");//Number of output mergertree files 
+        return EXIT_SUCCESS;
+
+    case lhalo_binary:
+        fprintf(stderr, "If the file is binary then this function should never be called.  Something's gone wrong...");
+        return EXIT_FAILURE;
+
+    default:
+        fprintf(stderr, "Your tree type has not been included in the switch statement for ``%s`` in file ``%s``.\n", __FUNCTION__, __FILE__);
+        fprintf(stderr, "Please add it there.\n");
+        return EXIT_FAILURE;
+
+    }
+
+    return EXIT_FAILURE;
+}

--- a/src/io/hdf5_read_utils.h
+++ b/src/io/hdf5_read_utils.h
@@ -22,7 +22,7 @@ extern "C" {
         hid_t h5_space = H5Dget_space(h5_dset);                         \
         XRETURN(h5_space >= 0, -HDF5_ERROR, "Error: Could not reserve filespace for open dataset = '%s' (within group = '%s')\n", dataset_name, group_name); \
         hsize_t rank = H5Sget_simple_extent_ndims(h5_space);                                            \
-        XRETURN(rank == ndim, -HDF5_ERROR, "Error: rank = %lld should be equal to ndim = %lld\n", rank, ndim);\
+        XRETURN(rank == (int) ndim, -HDF5_ERROR, "Error: rank = %lld should be equal to ndim = %lld\n", rank, ndim);\
         herr_t macro_status = H5Sselect_hyperslab(h5_space, H5S_SELECT_SET, offset, NULL, count, NULL); \
         XRETURN(macro_status >= 0, -HDF5_ERROR,                          \
                 "Error: Failed to select hyperslab for dataset = '%s'.\n" \

--- a/src/io/hdf5_read_utils.h
+++ b/src/io/hdf5_read_utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <hdf5.h>
+#include "../core_allvars.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -9,6 +10,52 @@ extern "C" {
     extern herr_t read_attribute(hid_t fd, const char *group_name, const char *attr_name, void *attribute, const size_t dst_size);
     extern herr_t read_dataset_shape(hid_t fd, const char *dataset_name, int *ndims, hsize_t **dims);
     extern herr_t read_dataset(hid_t fd, const char *dataset_name, hid_t dataset_id, void *buffer, const size_t dst_size, const int check_size);
+    extern int32_t fill_hdf5_metadata_names(struct HDF5_METADATA_NAMES *metadata_names, enum Valid_TreeTypes my_TreeType);
+
+
+// Handy macro
+#define READ_PARTIAL_DATASET(fd, group_name, dataset_name, ndim, offset, count, buffer) { \
+        hid_t h5_grp = H5Gopen(fd, group_name, H5P_DEFAULT);            \
+        XRETURN(h5_grp >= 0, -HDF5_ERROR, "Error: Could not open group = '%s'\n", group_name); \
+        hid_t h5_dset = H5Dopen2(h5_grp, dataset_name, H5P_DEFAULT);    \
+        XRETURN(h5_dset >= 0, -HDF5_ERROR, "Error: Could not open dataset = '%s' (within group = '%s')\n", dataset_name, group_name); \
+        hid_t h5_space = H5Dget_space(h5_dset);                         \
+        XRETURN(h5_space >= 0, -HDF5_ERROR, "Error: Could not reserve filespace for open dataset = '%s' (within group = '%s')\n", dataset_name, group_name); \
+        hsize_t rank = H5Sget_simple_extent_ndims(h5_space);                                            \
+        XRETURN(rank == ndim, -HDF5_ERROR, "Error: rank = %lld should be equal to ndim = %lld\n", rank, ndim);\
+        herr_t macro_status = H5Sselect_hyperslab(h5_space, H5S_SELECT_SET, offset, NULL, count, NULL); \
+        XRETURN(macro_status >= 0, -HDF5_ERROR,                          \
+                "Error: Failed to select hyperslab for dataset = '%s'.\n" \
+                "The dimensions of the dataset was %"PRIu64", count[0] = %"PRIu64"\nThe file ID was %d\n.", \
+                dataset_name, (uint64_t) ndim, (uint64_t) *count, (int32_t) fd); \
+        hid_t h5_memspace = H5Screate_simple(ndim, count, NULL);        \
+        XRETURN(h5_memspace >= 0, -HDF5_ERROR,                           \
+                "Error: Failed to create memory space for dataset = '%s'.\n" \
+                "The dimensions of the dataset was %"PRIu64", count[0] = %"PRIu64"\nThe file ID was %d\n.", \
+                dataset_name, (uint64_t) ndim, (uint64_t) *count, (int32_t) fd); \
+        const hid_t h5_dtype = H5Dget_type(h5_dset);                    \
+        macro_status = H5Dread(h5_dset, h5_dtype, h5_memspace, h5_space, H5P_DEFAULT, buffer); \
+        XRETURN(macro_status >= 0, -HDF5_ERROR, "Error: Failed to read array for dataset = '%s'.\n" \
+                "The dimensions of the dataset was %"PRIu64", count[0] = %"PRIu64"\nThe file ID was %d\n.", \
+                dataset_name, (uint64_t) ndim, (uint64_t) *count, (int32_t) fd); \
+        XRETURN(H5Dclose(h5_dset) >= 0, -HDF5_ERROR,                     \
+                "Error: Could not close dataset = '%s' (within group = '%s')\n", \
+                dataset_name, group_name);                              \
+        XRETURN(H5Tclose(h5_dtype) >= 0, -HDF5_ERROR,                    \
+                "Error: Failed to close the datatype for = %s.\n"       \
+                "The dimensions of the dataset was %"PRIu64", count[0] = %"PRIu64"\nThe file ID was %d\n.", \
+                dataset_name, (uint64_t) ndim, (uint64_t) *count, (int32_t) fd); \
+        XRETURN(H5Sclose(h5_memspace) >= 0, -HDF5_ERROR,                 \
+                "Error: Failed to close the dataspace for = %s.\n"      \
+                "The dimensions of the dataset was %"PRIu64", count[0] = %"PRIu64"\nThe file ID was %d\n.", \
+                dataset_name, (uint64_t) ndim, (uint64_t) *count, (int32_t) fd); \
+        XRETURN(H5Sclose(h5_space) >= 0, -HDF5_ERROR,                    \
+                "Error: Failed to close the filespace for = %s.\n"      \
+                "The dimensions of the dataset was %"PRIu64", count[0] = %"PRIu64"\nThe file ID was %d\n.", \
+                dataset_name, (uint64_t) ndim, (uint64_t) *count, (int32_t) fd); \
+        XRETURN(H5Gclose(h5_grp) >= 0, -HDF5_ERROR, "Error: Could not close group = '%s'\n", group_name); \
+    }
+
 
 #ifdef __cplusplus
 }

--- a/src/io/read_tree_gadget4_hdf5.c
+++ b/src/io/read_tree_gadget4_hdf5.c
@@ -15,7 +15,7 @@
 
 
 /* Local Proto-Types */
-static int convert_units_for_forest(struct halo_data *halos, const int64_t nhalos, const double hubble);
+static int convert_units_for_forest(struct halo_data *halos, const int64_t nhalos);
 static void get_forests_filename_gadget4_hdf5(char *filename, const size_t len, const int filenr, const struct params *run_params);
 
 int load_tree_table_gadget4_hdf5(const int firstfile, const int lastfile, const int64_t *totnforests_per_file, 
@@ -572,7 +572,7 @@ int setup_forests_io_gadget4_hdf5(struct forest_info *forests_info,
 
 
 
-int64_t load_forest_gadget4_hdf5(const int64_t forestnr, struct halo_data **halos, struct forest_info *forests_info, const double hubble)
+int64_t load_forest_gadget4_hdf5(const int64_t forestnr, struct halo_data **halos, struct forest_info *forests_info)
 {
 
     /* Since the Gadget4 mergertree allows trees to be split across multiple files, we need to loop over the files */
@@ -657,7 +657,7 @@ int64_t load_forest_gadget4_hdf5(const int64_t forestnr, struct halo_data **halo
     local_halos -= nhalos;
 
     free(buffer);
-    int status = convert_units_for_forest(*halos, nhalos, hubble);
+    int status = convert_units_for_forest(*halos, nhalos);
     if(status != EXIT_SUCCESS) {
         return -1;
     }
@@ -692,9 +692,8 @@ int64_t load_forest_gadget4_hdf5(const int64_t forestnr, struct halo_data **halo
 #undef READ_TREE_PROPERTY_MULTIPLEDIM
 
 
-int convert_units_for_forest(struct halo_data *halos, const int64_t nhalos, const double hubble)
+int convert_units_for_forest(struct halo_data *halos, const int64_t nhalos)
 {
-    (void ) hubble;
     if (nhalos <= 0) {
         fprintf(stderr,"Strange!: In function %s> Got nhalos = %"PRId64". Expected to get nhalos > 0\n", __FUNCTION__, nhalos);
         return -1;

--- a/src/io/read_tree_gadget4_hdf5.c
+++ b/src/io/read_tree_gadget4_hdf5.c
@@ -629,7 +629,7 @@ int64_t load_forest_gadget4_hdf5(const int64_t forestnr, struct halo_data **halo
         READ_TREE_PROPERTY(fd, nhalo_offset, Len, "SubhaloLen", numhalos_this_file, int);
         // READ_TREE_PROPERTY(fd, nhalo_offset, M_Mean200, Group_M_Mean200, numhalos_this_file, float);//MS: units 10^10 Msun/h for all Illustris mass fields
         // READ_TREE_PROPERTY(fd, nhalo_offset, M_Mean200, "SubhaloMass", numhalos_this_file, float);//MS: units 10^10 Msun/h for all Illustris mass fields
-        READ_TREE_PROPERTY(fd, nhalo_offset, Mvir, "SubhaloMass", numhalos_this_file, float);//MS: 16/9/2019 sage uses Mvir but assumes that contains M200c
+        READ_TREE_PROPERTY(fd, nhalo_offset, Mvir, "Group_M_Crit200", numhalos_this_file, float);//MS: 16/9/2019 sage uses Mvir but assumes that contains M200c
         // READ_TREE_PROPERTY(fd, nhalo_offset, M_TopHat, Group_M_TopHat200, numhalos_this_file, float);
         READ_TREE_PROPERTY_MULTIPLEDIM(fd, multi_dim_offset, Pos, "SubhaloPos", 3, multi_dim_count, float);//needs to be converted from kpc/h -> Mpc/h
         READ_TREE_PROPERTY_MULTIPLEDIM(fd, multi_dim_offset, Vel, "SubhaloVel", 3, multi_dim_count, float);//km/s

--- a/src/io/read_tree_gadget4_hdf5.c
+++ b/src/io/read_tree_gadget4_hdf5.c
@@ -15,7 +15,6 @@
 
 
 /* Local Proto-Types */
-static int convert_units_for_forest(struct halo_data *halos, const int64_t nhalos);
 static void get_forests_filename_gadget4_hdf5(char *filename, const size_t len, const int filenr, const struct params *run_params);
 
 int load_tree_table_gadget4_hdf5(const int firstfile, const int lastfile, const int64_t *totnforests_per_file, 
@@ -657,10 +656,6 @@ int64_t load_forest_gadget4_hdf5(const int64_t forestnr, struct halo_data **halo
     local_halos -= nhalos;
 
     free(buffer);
-    int status = convert_units_for_forest(*halos, nhalos);
-    if(status != EXIT_SUCCESS) {
-        return -1;
-    }
 
     /* Since the Gadget4 mergertree is by far the most complicated among all the supported formats,
         we have this extra validation step within the load routine. MS 29/07/2023 */
@@ -694,32 +689,9 @@ int64_t load_forest_gadget4_hdf5(const int64_t forestnr, struct halo_data **halo
 #undef READ_TREE_PROPERTY_MULTIPLEDIM
 
 
-int convert_units_for_forest(struct halo_data *halos, const int64_t nhalos)
-{
-    if (nhalos <= 0) {
-        fprintf(stderr,"Strange!: In function %s> Got nhalos = %"PRId64". Expected to get nhalos > 0\n", __FUNCTION__, nhalos);
-        return -1;
-    }
-
-    // const float spin_conv_fac = (float) (0.001/hubble);
-
-    /* Any unit conversions or resetting thing that need to be done */
-    for(int64_t i=0;i<nhalos;i++) {
-        halos[i].SubHalfMass = -1.0f;
-        halos[i].FileNr = -1;//FileNr is stored at the forest level and *NOT* the halo level
-    }
-
-    return EXIT_SUCCESS;
-}
-
-
 void cleanup_forests_io_gadget4_hdf5(struct forest_info *forests_info)
 {
     struct gadget4_info *g4 = &(forests_info->gadget4);
-    // myfree(g4->h5_fd);
-    // const ssize_t nleaks = H5Fget_obj_count(H5F_OBJ_ALL, H5F_OBJ_ALL);
-    // fprintf(stderr,"Should be numfiles = %d for hdf5 nleaks = %zd\n", g4->numfiles, nleaks);
-
     for(int32_t i=0;i<g4->numfiles;i++) {
         /* could use 'H5close' instead to make sure any open datasets are also
            closed; but that would hide potential bugs in code.

--- a/src/io/read_tree_gadget4_hdf5.c
+++ b/src/io/read_tree_gadget4_hdf5.c
@@ -14,16 +14,6 @@
 #include "forest_utils.h"
 
 
-// /* Local Structs */
-// struct METADATA_NAMES
-// {
-//     char name_NTrees[MAX_STRING_LEN];
-//     char name_totNHalos[MAX_STRING_LEN];
-//     char name_TreeNHalos[MAX_STRING_LEN];
-//     char name_ParticleMass[MAX_STRING_LEN];
-//     char name_NumSimulationTreeFiles[MAX_STRING_LEN];
-// };
-
 /* Local Proto-Types */
 static int convert_units_for_forest(struct halo_data *halos, const int64_t nhalos, const double hubble);
 static void get_forests_filename_gadget4_hdf5(char *filename, const size_t len, const int filenr, const struct params *run_params);
@@ -192,14 +182,11 @@ int setup_forests_io_gadget4_hdf5(struct forest_info *forests_info,
     }
     forests_info->nhalos_this_task = nhalos_this_task;
 
-    int64_t end_halonum_for_end_forestnum = 0, start_halonum_for_start_forestnum = 0;
+    int64_t end_halonum_for_end_forestnum = 0;
     for(int64_t i=0;i<=end_forestnum;i++) {
         end_halonum_for_end_forestnum += nhalos_per_forest[i];
-        if(i < start_forestnum) start_halonum_for_start_forestnum += nhalos_per_forest[i];
     }
-    end_halonum_for_end_forestnum--;/* inclusive - that's why we need the -1. However, we do not need the -1 
-                                       start_halonum_for_start_forestnum, because that starts *exactly* 1 halo 
-                                       after the end of the previous tree. */   
+    end_halonum_for_end_forestnum--;/* inclusive - that's why we need the -1. */
 
 
     int64_t *num_forests_to_process_per_file = calloc((lastfile + 1), sizeof(num_forests_to_process_per_file[0]));/* calloc is required */

--- a/src/io/read_tree_gadget4_hdf5.c
+++ b/src/io/read_tree_gadget4_hdf5.c
@@ -6,7 +6,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
-
+#include <hdf5.h>
 
 #include "read_tree_gadget4_hdf5.h"
 #include "hdf5_read_utils.h"

--- a/src/io/read_tree_gadget4_hdf5.c
+++ b/src/io/read_tree_gadget4_hdf5.c
@@ -1,0 +1,815 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <time.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+
+#include "read_tree_gadget4_hdf5.h"
+#include "hdf5_read_utils.h"
+#include "../core_mymalloc.h"
+#include "forest_utils.h"
+
+
+// /* Local Structs */
+// struct METADATA_NAMES
+// {
+//     char name_NTrees[MAX_STRING_LEN];
+//     char name_totNHalos[MAX_STRING_LEN];
+//     char name_TreeNHalos[MAX_STRING_LEN];
+//     char name_ParticleMass[MAX_STRING_LEN];
+//     char name_NumSimulationTreeFiles[MAX_STRING_LEN];
+// };
+
+/* Local Proto-Types */
+static int convert_units_for_forest(struct halo_data *halos, const int64_t nhalos, const double hubble);
+static void get_forests_filename_gadget4_hdf5(char *filename, const size_t len, const int filenr, const struct params *run_params);
+
+int load_tree_table_gadget4_hdf5(const int firstfile, const int lastfile, const int64_t *totnforests_per_file, 
+                                 const struct params *run_params, const int ThisTask, 
+                                 int64_t *nhalos_per_forest);
+
+void get_forests_filename_gadget4_hdf5(char *filename, const size_t len, const int filenr,  const struct params *run_params)
+{
+    snprintf(filename, len - 1, "%s/%s.%d%s", run_params->SimulationDir, run_params->TreeName, filenr, run_params->TreeExtension);
+}
+
+
+int setup_forests_io_gadget4_hdf5(struct forest_info *forests_info,
+                                  const int ThisTask, const int NTasks, struct params *run_params)
+{
+    const int firstfile = run_params->FirstFile;
+    const int lastfile = run_params->LastFile;
+    const int numfiles = lastfile - firstfile + 1;
+    if(numfiles <= 0) {
+        return -1;
+    }
+
+    /* We can not determine the halo offset to start reading from within 'firstfile' unless we have access to *all* previous files */
+    if(firstfile != 0) {
+        fprintf(stderr, "Error: Since the Gadget4 mergertrees can be split across files, we *have* to begin processing at the 0'th file\n");
+        fprintf(stderr,"If you are confident that the first tree located within 'firstfile' = %d begins at 0 halo offset (i.e., there "
+                       "are no previous trees whose halos are contained within 'firstfile', then you can comment out this error at your own risk)\n",
+                       firstfile);
+        return -1;
+    }
+
+    /* wasteful to allocate for lastfile + 1 indices, rather than numfiles; but makes indexing easier */
+    int64_t *totnforests_per_file = calloc(lastfile + 1, sizeof(totnforests_per_file[0]));
+    if(totnforests_per_file == NULL) {
+        fprintf(stderr,"Error: Could not allocate memory to store the number of forests in each file\n");
+        perror(NULL);
+        return MALLOC_FAILURE;
+    }
+    struct gadget4_info *g4 = &(forests_info->gadget4);
+
+    struct HDF5_METADATA_NAMES metadata_names;
+    int status = fill_hdf5_metadata_names(&metadata_names, run_params->TreeType);
+    if (status != EXIT_SUCCESS) {
+        return -1;
+    }
+
+    int64_t totnforests = 0, sanity_check_totnforests;
+    /* Extra step for Gadget4 hdf5 format since the forests can span multiple files 
+       -> need to calculate (for each forest) how many files the forest is spread across, 
+          and the start and end halo number within each file. Most forests will likely be within
+          one file, but this design helps simplify the code in the `load_halos` function MS 13th June, 2023 */
+
+    int64_t *nhalos_per_file = malloc( (lastfile + 1)*sizeof(*nhalos_per_file) );
+    CHECK_POINTER_AND_RETURN_ON_NULL(nhalos_per_file, "Failed to allocate %d elements of size %zu for nhalos per file\n", 
+                                     (lastfile + 1),
+                                     sizeof(*nhalos_per_file));
+
+    for(int filenr=firstfile;filenr<=lastfile;filenr++) {
+        char filename[4*MAX_STRING_LEN];
+        get_forests_filename_gadget4_hdf5(filename, 4*MAX_STRING_LEN, filenr, run_params);
+        hid_t fd = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT);
+        XRETURN (fd > 0, FILE_NOT_FOUND,
+                 "Error: can't open file `%s'\n", filename);
+
+#define READ_G4_ATTRIBUTE(hid, groupname, attrname, dst) {           \
+            herr_t h5_status = read_attribute(hid, groupname, attrname, (void *) &dst, sizeof(dst)); \
+            if(h5_status < 0) {                                         \
+                return (int) h5_status;                                 \
+            }                                                           \
+        }
+
+        if(filenr == firstfile) {
+            //Check if the number of simulation output files have been set correctly
+            int32_t numsimulationfiles;
+            READ_G4_ATTRIBUTE(fd, "/Header", metadata_names.name_NumSimulationTreeFiles, numsimulationfiles);
+
+            if(numsimulationfiles != run_params->NumSimulationTreeFiles) {
+                fprintf(stderr,"Error: Parameter file mentions total number of simulation output files = %d but the "
+                        "hdf5 field `%s' says %d tree files\n",
+                        run_params->NumSimulationTreeFiles, metadata_names.name_NumSimulationTreeFiles, numsimulationfiles);
+                fprintf(stderr,"May be the value in the parameter file needs to be updated?\n");
+                return -1;
+            }
+
+            // Read totnforests over across all files to sanity check the value at the end
+            READ_G4_ATTRIBUTE(fd, "/Header", "Ntrees_Total", sanity_check_totnforests);
+            if(sanity_check_totnforests <= 0) {
+                fprintf(stderr,"Error: Total number of trees = %"PRId64" should be >=1\n", sanity_check_totnforests);
+                return -1;
+            }
+
+            READ_G4_ATTRIBUTE(fd, "/Header", "Nhalos_Total", forests_info->totnhalos);
+            if(forests_info->totnhalos <= 0) {
+                fprintf(stderr,"Error: Total number of halos = %"PRId64" should be >=1\n", forests_info->totnhalos);
+                return -1;
+            }
+
+            // Read and check boxsize, Omega0, OmegaLambda, Hubble
+            #define SANITY_CHECK_FLOAT64_ATTRIBUTE(hid, groupname, attrname, dst, expected_value, tolerance) { \
+                READ_G4_ATTRIBUTE(hid, groupname, attrname, dst);                                              \
+                XRETURN(fabs(dst - expected_value) < tolerance, -1,                                            \
+                        "Error: Expected value for '" #attrname "' = %g "                                      \
+                        "but found %g instead in hdf5 file\n", expected_value, dst);                           \
+            }
+            double tmp;
+            const double tolerance = 1e-6;
+            SANITY_CHECK_FLOAT64_ATTRIBUTE(fd, "/Parameters", "BoxSize", tmp, run_params->BoxSize, tolerance);
+            SANITY_CHECK_FLOAT64_ATTRIBUTE(fd, "/Parameters", "Omega0", tmp, run_params->Omega, tolerance);
+            SANITY_CHECK_FLOAT64_ATTRIBUTE(fd, "/Parameters", "OmegaLambda", tmp, run_params->OmegaLambda, tolerance);
+            SANITY_CHECK_FLOAT64_ATTRIBUTE(fd, "/Parameters", "HubbleParam", tmp, run_params->Hubble_h, tolerance);
+            #undef SANITY_CHECK_FLOAT64_ATTRIBUTE
+
+        }
+
+        uint64_t nforests_thisfile;
+        READ_G4_ATTRIBUTE(fd, "/Header", metadata_names.name_NTrees, nforests_thisfile);
+#ifdef DEBUG_PRINT        
+        fprintf(stderr,"[On ThisTask = %d] filenr = %d nforests_thisfile attribute = %"PRIu64"\n", ThisTask, filenr, nforests_thisfile);
+#endif
+        totnforests_per_file[filenr] = nforests_thisfile;
+        totnforests += nforests_thisfile;
+
+        int64_t nhalos_thisfile;
+        READ_G4_ATTRIBUTE(fd, "/Header", metadata_names.name_totNHalos, nhalos_thisfile);
+        nhalos_per_file[filenr] = nhalos_thisfile;
+
+        XRETURN( H5Fclose(fd) >= 0, -1, "Error: Could not close hdf5 file `%s`\n", filename);
+    }
+    if(run_params->NumSimulationTreeFiles == (lastfile - firstfile + 1)) {
+        XRETURN( sanity_check_totnforests == totnforests, -1, "Error: Total number of trees = %" PRId64" "
+                "read in from firstfile = %d should match the number of forests summed across all files = %"PRId64"\n",
+                sanity_check_totnforests, firstfile, totnforests);
+    }
+    forests_info->totnforests = totnforests;/* forests_info->totnhalos has already been set */
+
+    // const int need_nhalos_per_forest = run_params->ForestDistributionScheme == uniform_in_forests ? 0:1;
+    int64_t *nhalos_per_forest = malloc(totnforests * sizeof(*nhalos_per_forest));  
+    CHECK_POINTER_AND_RETURN_ON_NULL(nhalos_per_forest,
+                                    "Failed to allocate %"PRId64" elements of size %zu for nhalos_per_forest", totnforests,
+                                    sizeof(*(nhalos_per_forest)));
+
+    status = load_tree_table_gadget4_hdf5(firstfile, lastfile, totnforests_per_file, run_params, ThisTask, nhalos_per_forest);
+    if(status != EXIT_SUCCESS) {
+        return status;
+    }
+
+    int64_t nforests_this_task, start_forestnum;
+    status = distribute_weighted_forests_over_ntasks(totnforests, nhalos_per_forest,
+                                                    run_params->ForestDistributionScheme, run_params->Exponent_Forest_Dist_Scheme,
+                                                    NTasks, ThisTask, &nforests_this_task, &start_forestnum);
+    if(status != EXIT_SUCCESS) {
+        return status;
+    }
+
+    const int64_t end_forestnum = start_forestnum + nforests_this_task - 1; /* inclusive, i.e., DO process forestnr == end_forestnum */
+#ifdef DEBUG_PRINT    
+    fprintf(stderr,"Thistask = %d start_forestnum = %"PRId64" end_forestnum = %"PRId64"\n", ThisTask, start_forestnum, end_forestnum);
+#endif
+    forests_info->nforests_this_task = nforests_this_task;
+    g4->nforests = nforests_this_task;
+    int64_t nhalos_this_task = 0;
+    for(int64_t i=start_forestnum;i<=end_forestnum;i++) {
+        nhalos_this_task += nhalos_per_forest[i];
+    }
+    forests_info->nhalos_this_task = nhalos_this_task;
+
+    int64_t end_halonum_for_end_forestnum = 0, start_halonum_for_start_forestnum = 0;
+    for(int64_t i=0;i<=end_forestnum;i++) {
+        end_halonum_for_end_forestnum += nhalos_per_forest[i];
+        if(i < start_forestnum) start_halonum_for_start_forestnum += nhalos_per_forest[i];
+    }
+    end_halonum_for_end_forestnum--;/* inclusive - that's why we need the -1. However, we do not need the -1 
+                                       start_halonum_for_start_forestnum, because that starts *exactly* 1 halo 
+                                       after the end of the previous tree. */   
+
+
+    int64_t *num_forests_to_process_per_file = calloc((lastfile + 1), sizeof(num_forests_to_process_per_file[0]));/* calloc is required */
+    int64_t *start_forestnum_to_process_per_file = malloc((lastfile + 1) * sizeof(start_forestnum_to_process_per_file[0]));
+    if(num_forests_to_process_per_file == NULL || start_forestnum_to_process_per_file == NULL) {
+    // if(num_forests_to_process_per_file == NULL ) {
+        fprintf(stderr,"Error: Could not allocate memory to store the number of forests that need to be processed per file (on thistask=%d)\n", ThisTask);
+        perror(NULL);
+        return MALLOC_FAILURE;
+    }
+
+    int *end_filenum_for_last_forest_in_file = malloc((lastfile + 1) * sizeof(*end_filenum_for_last_forest_in_file));
+    CHECK_POINTER_AND_RETURN_ON_NULL(end_filenum_for_last_forest_in_file, "Error: Could not allocate memory to store the end filenum for the last forest in file\n");
+
+    int64_t *end_forestnum_for_last_forest_in_file = malloc((lastfile + 1) * sizeof(end_forestnum_for_last_forest_in_file));
+    CHECK_POINTER_AND_RETURN_ON_NULL(end_forestnum_for_last_forest_in_file, "Error: Could not allocate memory to store the end filenum for the last forest in file\n");
+
+    int64_t *end_halonum_in_file = malloc((lastfile + 1) * sizeof(*end_halonum_in_file));   
+    CHECK_POINTER_AND_RETURN_ON_NULL(end_halonum_in_file, "Error: Could not allocate memory to store the cumulative number of halos encountered  in files\n");
+
+    /* contains the file-local offset in units of nhalos (not bytes) for the beginning of the *first* 'new' forest 
+        within the file. Typically, would be 0 when the first forest begins as the start of the file; however, since
+        a previous tree may have been split into this file, the offset needs to be adjusted accordingly (i.e., if the 
+        previous tree has, say 126 halos within this file, then the offset for the first new tree will be '126' (0-based indexing for C))
+        - MS 6th Jul, 2023
+    */
+
+    int start_filenum=-1, end_filenum=-1;
+    int64_t nhalos_so_far = 0, nforests_so_far = 0;
+    for(int filenr=firstfile;filenr<=lastfile;filenr++) {
+        end_halonum_in_file[filenr] = nhalos_so_far + nhalos_per_file[filenr] - 1;/* storing the last halo number (cumulative across all previous files)*/
+        end_forestnum_for_last_forest_in_file[filenr] = nforests_so_far + totnforests_per_file[filenr];/* storing the last forest number */
+        if(totnforests_per_file[filenr] > 0) end_forestnum_for_last_forest_in_file[filenr]--; /* Only do the decrement if at least one new forest was found
+                                                                                                in this file. Otherwise, preserve the forestnumber from the 
+                                                                                                last file where a *new* forest was present */
+
+        start_forestnum_to_process_per_file[filenr] = 0;
+        num_forests_to_process_per_file[filenr] = totnforests_per_file[filenr];
+
+        /* We can use forest number to get 'start_filenum'; however, since the 'end_forestnum' tree might be split across many files,
+        we have to use 'halonum' to detect the final file that needs to be opened for completing all the halos in 'end_halonum' */
+        if(start_forestnum >= nforests_so_far && start_forestnum <= end_forestnum_for_last_forest_in_file[filenr]) {
+            start_filenum = filenr;
+            start_forestnum_to_process_per_file[filenr] = start_forestnum - nforests_so_far;
+            num_forests_to_process_per_file[filenr] = totnforests_per_file[filenr] - (start_forestnum - nforests_so_far);
+        }
+
+        if(end_halonum_for_end_forestnum >= nhalos_so_far && end_halonum_for_end_forestnum <= end_halonum_in_file[filenr]) {
+            end_filenum = filenr;
+            num_forests_to_process_per_file[filenr] = end_forestnum - (start_forestnum_to_process_per_file[filenr] + nforests_so_far);
+        }
+
+        nhalos_so_far += nhalos_per_file[filenr];
+        nforests_so_far += totnforests_per_file[filenr];
+#ifdef DEBUG_PRINT                
+        if(ThisTask == 0) {
+            fprintf(stderr,"end_forestnum_for_last_forest_in_file[%03d] = %08"PRId64" nhalos_so_far = %10"PRId64" nhalos_per_forest = %10"PRId64" end_halonum_in_file = %10"PRId64"\n", 
+                            filenr, end_forestnum_for_last_forest_in_file[filenr], nhalos_so_far, nhalos_per_forest[nforests_so_far-1], end_halonum_in_file[filenr]);
+
+        }
+#endif        
+    }
+    XRETURN(start_filenum != -1 && end_filenum != -1, -1, 
+            "Error: Could not locate start_filenum ()= %d) and/or end_filenum (=%d)\n", start_filenum, end_filenum);
+
+    g4->numfiles = end_filenum - start_filenum + 1;
+    g4->open_h5_fds = mymalloc(g4->numfiles * sizeof(g4->open_h5_fds[0]));
+    XRETURN(g4->open_h5_fds != NULL, MALLOC_FAILURE, "Error: Could not allocate memory of size %zu bytes"
+                                                     " to hold open HDF5 file pointers for %d files\n", 
+                                                     g4->numfiles * sizeof(g4->open_h5_fds[0]), g4->numfiles);
+
+    /* Now we can open the needed files for later reading in 'load_forest_gadget4_hdf5'*/
+    for(int filenr=start_filenum;filenr<=end_filenum;filenr++) {
+        char filename[4*MAX_STRING_LEN];
+        get_forests_filename_gadget4_hdf5(filename, 4*MAX_STRING_LEN, filenr, run_params);
+        hid_t fd = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT);
+        XRETURN (fd > 0, FILE_NOT_FOUND,
+                 "Error: can't open file `%s'\n", filename);
+        g4->open_h5_fds[filenr - start_filenum] = fd;
+    }
+
+    int64_t *nhalo_offset_first_forest_in_file = calloc( (lastfile + 1), sizeof(*nhalo_offset_first_forest_in_file) );
+    CHECK_POINTER_AND_RETURN_ON_NULL(nhalo_offset_first_forest_in_file, "Failed to allocate %d elements of size %zu for nhalo_offset_first_forest_in_file\n", 
+                                     (lastfile + 1),
+                                     sizeof(*nhalo_offset_first_forest_in_file));
+
+    g4->num_files_per_forest = mymalloc(nforests_this_task * sizeof(g4->num_files_per_forest[0]));
+    CHECK_POINTER_AND_RETURN_ON_NULL(g4->num_files_per_forest,
+                                     "Failed to allocate %"PRId64" elements of size %zu for gadget4->num_files_per_forest", nforests_this_task,
+                                     sizeof(*(g4->num_files_per_forest)));
+
+    forests_info->FileNr = mymalloc(nforests_this_task * sizeof(*(forests_info->FileNr)));
+    CHECK_POINTER_AND_RETURN_ON_NULL(forests_info->FileNr,
+                                     "Failed to allocate %"PRId64" elements of size %zu for forests_info->FileNr", nforests_this_task,
+                                     sizeof(*(forests_info->FileNr)));
+
+    forests_info->original_treenr = mymalloc(nforests_this_task * sizeof(*(forests_info->original_treenr)));
+    CHECK_POINTER_AND_RETURN_ON_NULL(forests_info->original_treenr,
+                                     "Failed to allocate %"PRId64" elements of size %zu for forests_info->original_treenr", nforests_this_task,
+                                     sizeof(*(forests_info->original_treenr)));
+
+    int filenr = firstfile;
+    XRETURN(firstfile == 0, -1, "Error: 'firstfile' = %d must be 0 for Gadget4 mergertree type", firstfile);
+    nhalo_offset_first_forest_in_file[filenr] = 0;/* This assumes firstfile == 0*/
+    nhalos_so_far = 0;
+
+    int64_t nhalos_left_this_file = nhalos_per_file[filenr];
+    int64_t file_nhalo_offset = 0;
+    int64_t file_nhalo_offset_for_start_forestnum = 0;
+    int64_t file_local_treenum = 0;
+    for(int64_t i=0;i<totnforests;i++) {
+        int numfiles_this_forest = 1;
+        int start_filenr = filenr;
+        if(i == start_forestnum) {
+            file_nhalo_offset_for_start_forestnum = file_nhalo_offset;
+#ifdef DEBUG_PRINT                           
+            fprintf(stderr,"CALCULATING NHALO OFFSET FOR START_FORESTNUM (ThisTask = %d) start_filenr = %d file_nhalo_offset_for_start_forestnum = %"PRId64" numfiles_per_forest[%"PRId64"] = %d\n", 
+                            ThisTask, start_filenr, file_nhalo_offset_for_start_forestnum, i, numfiles_this_forest);
+#endif                            
+        }
+
+        if(i == end_forestnum_for_last_forest_in_file[filenr]) {
+            int64_t nhalos_left_this_forest = nhalos_per_forest[i];
+            while(nhalos_left_this_forest > nhalos_left_this_file) {
+#ifdef DEBUG_PRINT                
+                fprintf(stderr,"(BEFORE) Entering initial while loop: i = %"PRId64" filenr = %d numfiles = %d nhalos_left_this_forest = %"PRId64" nhalos_left_this_file = %"PRId64"\n", 
+                        i, filenr, numfiles_this_forest, nhalos_left_this_forest, nhalos_left_this_file);
+#endif
+
+                nhalos_left_this_forest -= nhalos_left_this_file;
+                numfiles_this_forest++;
+                filenr++;
+
+            
+                XRETURN( filenr <= lastfile, -1, 
+                        "(ThisTask = %d) filenr = %d should have been <= lastfile = %d iforest = %"PRId64" nforests_this_task = %"PRId64" nhalos = %"PRId64"\n", 
+                        ThisTask, filenr, lastfile, i, nforests_this_task, nhalos_per_forest[i]);
+                nhalos_left_this_file = nhalos_per_file[filenr];
+                file_nhalo_offset = 0;
+                file_local_treenum = 0;
+#ifdef DEBUG_PRINT                
+                fprintf(stderr,"(AFTER) Entering initial while loop: i = %"PRId64" filenr = %d numfiles = %d nhalos_left_this_forest = %"PRId64" nhalos_left_this_file = %"PRId64"\n", 
+                        i, filenr, numfiles_this_forest, nhalos_left_this_forest, nhalos_left_this_file);
+#endif                        
+            }
+
+            XRETURN(filenr <= lastfile && nhalos_left_this_forest <= nhalos_left_this_file, -1, "Error: WHYYY");
+            if(nhalos_left_this_file == nhalos_left_this_forest) {
+                end_filenum_for_last_forest_in_file[start_filenr] = filenr;                   
+                nhalos_left_this_file = 0;
+                filenr++;
+                if(filenr <= lastfile) nhalos_left_this_file = nhalos_per_file[filenr]; /* filenr will be == (lastfile + 1)  after the increment when processing the final forest */
+                file_nhalo_offset = 0;
+                file_local_treenum = 0;
+            } else {
+                end_filenum_for_last_forest_in_file[start_filenr] = filenr;                   
+                nhalos_left_this_file -= nhalos_left_this_forest;
+                file_nhalo_offset += nhalos_left_this_forest;
+                nhalo_offset_first_forest_in_file[filenr] = file_nhalo_offset;
+                file_local_treenum++;
+            }
+        } else {
+            nhalos_left_this_file -= nhalos_per_forest[i];
+            file_nhalo_offset += nhalos_per_forest[i];
+            file_local_treenum++;
+        }
+
+        if(i >= start_forestnum && i <= end_forestnum) {
+            g4->num_files_per_forest[i - start_forestnum]  = numfiles_this_forest;
+            forests_info->FileNr[i - start_forestnum] = start_filenr;
+            forests_info->original_treenr[i - start_forestnum] = file_local_treenum;
+            // fprintf(stderr,"(ThisTask = %d) i = %"PRId64" start_filenr = %d numfiles = %d\n", ThisTask, i, start_filenr, numfiles_this_forest);
+        }
+
+        nhalos_so_far += nhalos_per_forest[i];
+    }
+    free(end_filenum_for_last_forest_in_file);
+    free(end_halonum_in_file);
+    free(end_forestnum_for_last_forest_in_file);
+
+
+
+    g4->nhalos_per_forest = mymalloc(nforests_this_task * sizeof(g4->nhalos_per_forest[0]));
+    CHECK_POINTER_AND_RETURN_ON_NULL(g4->nhalos_per_forest,
+                                     "Failed to allocate %"PRId64" elements of size %zu for gadget4->nhalos_per_forest", nforests_this_task,
+                                     sizeof(*(g4->nhalos_per_forest)));
+
+    XRETURN(sizeof(*g4->nhalos_per_forest) == sizeof(*nhalos_per_forest), -1, 
+            "Error: Mis-match in element size of the nhalos per forest array. Each element in source requires = %zd bytes"
+            ", while each element in the destination requires %zd bytes. Perhaps change the defintion of `nhalos_per_forest` "
+            "structure member within the 'struct gadget4_info' defined in 'core_allvars.h'\n", 
+            sizeof(*g4->nhalos_per_forest), sizeof(*nhalos_per_forest));
+    memcpy(g4->nhalos_per_forest, &nhalos_per_forest[start_forestnum], nforests_this_task * sizeof(*(g4->nhalos_per_forest)));
+    free(nhalos_per_forest);
+    nhalos_per_forest = g4->nhalos_per_forest;
+
+
+    g4->nhalos_per_file_per_forest = mymalloc(nforests_this_task * sizeof(g4->nhalos_per_file_per_forest[0]));
+    CHECK_POINTER_AND_RETURN_ON_NULL(g4->nhalos_per_file_per_forest,
+                                     "Failed to allocate %"PRId64" elements of size %zu for gadget4->nhalos_per_file_per_forest", nforests_this_task,
+                                     sizeof(*(g4->nhalos_per_file_per_forest)));
+
+    g4->offset_in_nhalos_first_file_for_forests = mymalloc(nforests_this_task * sizeof(g4->offset_in_nhalos_first_file_for_forests[0]));
+    CHECK_POINTER_AND_RETURN_ON_NULL(g4->offset_in_nhalos_first_file_for_forests,
+                                     "Failed to allocate %"PRId64" elements of size %zu for g4->offset_in_nhalos_first_file_for_forests", nforests_this_task,
+                                     sizeof(*(g4->offset_in_nhalos_first_file_for_forests)));
+
+    g4->start_h5_fd_index = mymalloc(nforests_this_task * sizeof(g4->start_h5_fd_index[0]));
+    CHECK_POINTER_AND_RETURN_ON_NULL(g4->start_h5_fd_index,
+                                     "Failed to allocate %"PRId64" elements of size %zu for g4->start_h5_fd_index", nforests_this_task,
+                                     sizeof(*(g4->start_h5_fd_index)));
+
+    /* Extra step for Gadget4 hdf5 format since the forests can span multiple files 
+       -> need to calculate (for each forest) how many files the forest is spread across, 
+          and the start and end halo number within each file. Most forests will likely be within
+          one file, but this design helps simplify the code in the `load_halos` function MS 13th June, 2023 */
+
+    /* In case 'start_filenum' != 0, we have to skip to where the halos begin in the
+    first forest in the file (i.e., after where the previous forest that started at an earlier 
+    file finishes). MS: 29th June, 2023 */   
+    filenr = start_filenum;                                    
+    file_nhalo_offset = file_nhalo_offset_for_start_forestnum;
+    nhalos_left_this_file = nhalos_per_file[start_filenum] - file_nhalo_offset_for_start_forestnum;
+
+    for(int64_t iforest=0;iforest<nforests_this_task;iforest++) {
+        g4->nhalos_per_file_per_forest[iforest] = calloc( g4->num_files_per_forest[iforest], sizeof(*(g4->nhalos_per_file_per_forest[iforest])));
+        CHECK_POINTER_AND_RETURN_ON_NULL(g4->nhalos_per_file_per_forest[iforest],
+                                        "Failed to allocate %d elements of size %zu for gadget4->nhalos_per_file_per_forest[%"PRId64"]", 
+                                        g4->num_files_per_forest[iforest],
+                                        sizeof(*(g4->nhalos_per_file_per_forest[iforest])), 
+                                        iforest);
+
+        g4->start_h5_fd_index[iforest] = filenr - start_filenum;
+        g4->offset_in_nhalos_first_file_for_forests[iforest] = file_nhalo_offset;
+
+        int64_t nhalos_left_this_forest = g4->nhalos_per_forest[iforest];
+        int64_t nhalos_assigned = 0;
+        int forest_numfiles_index = 0;
+        while(nhalos_left_this_forest > nhalos_left_this_file) {
+            XRETURN(forest_numfiles_index < g4->num_files_per_forest[iforest], -1, 
+                    "Error (on ThisTask=%d): forest_numfiles_index = %d should be less than g4->num_files_per_forest[%"PRId64"] = %d\n",
+                    ThisTask, forest_numfiles_index, iforest, g4->num_files_per_forest[iforest]);
+            g4->nhalos_per_file_per_forest[iforest][forest_numfiles_index] = nhalos_left_this_file;
+            nhalos_assigned += nhalos_left_this_file;
+#ifdef DEBUG_PRINT                
+            fprintf(stderr,"(BEFORE) filenr = %d iforest = %"PRId64" nhalos_left_this_forest "
+                           " = %"PRId64" nhalos_left_this_file = %"PRId64" nhalos_per_file_per_forest = %d nhalos_assigned = %"PRId64" forest_numfiles_index = %d\n",
+                           filenr, iforest, nhalos_left_this_forest, nhalos_left_this_file, 
+                           g4->nhalos_per_file_per_forest[iforest][forest_numfiles_index], nhalos_assigned, forest_numfiles_index);
+#endif                           
+
+            nhalos_left_this_forest -= nhalos_left_this_file;
+            forest_numfiles_index++;
+            filenr++;
+            
+            XRETURN( filenr <= end_filenum, -1, 
+                    "(ThisTask = %d) filenr = %d should have been <= end_filenum = %d iforest = %"PRId64" nforests_this_task = %"PRId64" nhalos = %"PRId64
+                    " nhalos_left_this_forest = %"PRId64" \n", 
+                    ThisTask, filenr, end_filenum, iforest, nforests_this_task, nhalos_per_forest[iforest], nhalos_left_this_forest);
+            file_nhalo_offset = 0;
+            if(filenr <= end_filenum) {
+                nhalos_left_this_file = nhalos_per_file[filenr];
+#ifdef DEBUG_PRINT                
+                fprintf(stderr,"(AFTER) filenr = %d iforest = %"PRId64" nhalos_left_this_forest "
+                            " = %"PRId64" nhalos_left_this_file = %"PRId64" nhalos_per_file_per_forest = %d nhalos_assigned = %"PRId64" forest_numfiles_index = %d\n",
+                            filenr, iforest, nhalos_left_this_forest, nhalos_left_this_file, 
+                            g4->nhalos_per_file_per_forest[iforest][forest_numfiles_index-1], nhalos_assigned, forest_numfiles_index);
+#endif                            
+            }
+
+        }
+
+
+        /* Two things need to be cross-checked - 
+            i) whether the realloc accounts for the final file that contains the last of the halos for a forest that spans mulltiple files
+            ii) whether the indexing with filenr is consistent with the memory allocation but also how the filenr is used in the other io loading
+            functions (i.e., index with potentially [filenr - start_filenum - 1] rather than [filenr - 1]
+            MS: 15th June, 2023
+        */
+        XRETURN(forest_numfiles_index < g4->num_files_per_forest[iforest], -1, 
+                "Error (on ThisTask=%d): forest_numfiles_index = %d should be less than g4->num_files_per_forest[%"PRId64"] = %d\n",
+                ThisTask, forest_numfiles_index, iforest, g4->num_files_per_forest[iforest]);
+
+        nhalos_assigned += nhalos_left_this_forest;
+
+        if (nhalos_left_this_forest < nhalos_left_this_file){
+            XRETURN(forest_numfiles_index < g4->num_files_per_forest[iforest], -1, 
+                    "Error (on ThisTask=%d): forest_numfiles_index = %d should be less than g4->num_files_per_forest[%"PRId64"] = %d\n",
+                    ThisTask, forest_numfiles_index, iforest, g4->num_files_per_forest[iforest]);
+            XRETURN(g4->nhalos_per_file_per_forest[iforest][forest_numfiles_index] == 0, -1, "Error: Code mnight be over-writing existing data");
+
+            g4->nhalos_per_file_per_forest[iforest][forest_numfiles_index] = nhalos_left_this_forest;
+            nhalos_left_this_file -= nhalos_left_this_forest;
+
+            file_nhalo_offset  += nhalos_left_this_forest;
+        } else if(nhalos_left_this_forest == nhalos_left_this_file) {
+            g4->nhalos_per_file_per_forest[iforest][forest_numfiles_index] = nhalos_left_this_forest;
+#ifdef DEBUG_PRINT            
+            fprintf(stderr,"EXACTLY EQUAL iforest = %"PRId64" filenr = %d forest_numfiles_index = %d g4->nhalos_per_file_per_forest[iforest][forest_numfiles_index] = %d\n\n",
+                           iforest, filenr, forest_numfiles_index, g4->nhalos_per_file_per_forest[iforest][forest_numfiles_index]);
+#endif                           
+            filenr++;
+            file_nhalo_offset = 0;
+            if(filenr <= end_filenum) nhalos_left_this_file = nhalos_per_file[filenr];
+        } 
+        else {
+            fprintf(stderr,"Error: Code logic should not have reached here\n");
+            return -1;
+        }
+        XRETURN( nhalos_assigned == g4->nhalos_per_forest[iforest], -1, 
+                 "Error: nhalos_assigned = %"PRId64"  should be *exactly* equal to nhalos_per_forest[%"PRId64"] = %"PRId64"\n", 
+                 nhalos_assigned, iforest, g4->nhalos_per_forest[iforest]);
+    }
+    free(nhalos_per_file);
+    free(nhalo_offset_first_forest_in_file);
+
+    for(int64_t i=0;i<nforests_this_task;i++) {
+        const int64_t expected_nhalos = g4->nhalos_per_forest[i];
+        int64_t check_nhalos = 0;
+        for(int j=0;j<g4->num_files_per_forest[i];j++) {
+            check_nhalos += g4->nhalos_per_file_per_forest[i][j];
+        }
+        XRETURN(check_nhalos == expected_nhalos, -1, 
+                "Error: For forestnum = %10"PRId64" expected to find %10"PRId64" halos but instead found %10"PRId64" halos (numfiles = %d)\n",
+                i + start_forestnum, expected_nhalos, check_nhalos, g4->num_files_per_forest[i]);
+    }
+
+
+    // We assume that each of the input tree files span the same volume. Hence by summing the
+    // number of trees processed by each task from each file, we can determine the
+    // fraction of the simulation volume that this task processes.  We weight this summation by the
+    // number of trees in each file because some files may have more/less trees whilst still spanning the
+    // same volume (e.g., a void would contain few trees whilst a dense knot would contain many).
+    forests_info->frac_volume_processed = 0.0;
+    for(int32_t ifile = start_filenum; ifile <= end_filenum; ifile++) {
+        if(totnforests_per_file[ifile] > 0) {
+            forests_info->frac_volume_processed += (double) num_forests_to_process_per_file[ifile] / (double) totnforests_per_file[ifile];
+        }
+    }
+    forests_info->frac_volume_processed /= (double) run_params->NumSimulationTreeFiles;
+
+    free(num_forests_to_process_per_file);
+    free(start_forestnum_to_process_per_file);
+    free(totnforests_per_file);
+
+    /* Finally setup the multiplication factors necessary to generate
+       unique galaxy indices (across all files, all trees and all tasks) for this run*/
+    run_params->FileNr_Mulfac = 1000000000000000LL;
+    run_params->ForestNr_Mulfac = 1000000000LL;
+
+    fprintf(stderr,"[On ThisTask = %d] start_forestnum = %"PRId64" end_forestnum = %"PRId64" start_filenum = %d end_filenum = %d "
+                    "file_nhalo_offset_for_start_forestnum = %"PRId64" end_halonum = %"PRId64"\n", 
+                    ThisTask, start_forestnum, end_forestnum, start_filenum, end_filenum, 
+                    file_nhalo_offset_for_start_forestnum, end_halonum_for_end_forestnum);
+
+    return EXIT_SUCCESS;
+
+
+}
+
+
+#define READ_TREE_PROPERTY(fd, offset, sage_name, dataset_name, count, C_dtype) { \
+        const long long ndim = 1;                                                  \
+        READ_PARTIAL_DATASET(fd, "TreeHalos", dataset_name, ndim, offset, count, buffer);\
+        C_dtype *macro_x = (C_dtype *) buffer;                          \
+        for (hsize_t halo_idx = 0; halo_idx < count[0]; halo_idx++){       \
+            local_halos[halo_idx].sage_name = *macro_x;                 \
+            macro_x++;                                                  \
+        }                                                               \
+    }
+
+#define READ_TREE_PROPERTY_MULTIPLEDIM(fd, offset, sage_name, dataset_name, ndim, count, C_dtype) { \
+        const long long dims = 2;                                                  \
+        READ_PARTIAL_DATASET(fd, "TreeHalos", dataset_name, dims, offset, count, buffer);\
+        C_dtype *macro_x = (C_dtype *) buffer;                          \
+        for (hsize_t halo_idx = 0; halo_idx < count[0]; halo_idx++){       \
+            for (int dim = 0; dim < NDIM; dim++) {                      \
+                local_halos[halo_idx].sage_name[dim] = *macro_x;        \
+                macro_x++;                                              \
+            }                                                           \
+        }                                                               \
+    }
+
+
+
+int64_t load_forest_gadget4_hdf5(const int64_t forestnr, struct halo_data **halos, struct forest_info *forests_info, const double hubble)
+{
+
+    /* Since the Gadget4 mergertree allows trees to be split across multiple files, we need to loop over the files */
+    const struct gadget4_info *g4 = &(forests_info->gadget4);
+    // const int64_t treenum_in_file = forests_info->original_treenr[forestnr];
+    const int64_t nhalos = g4->nhalos_per_forest[forestnr];
+
+    /* allocate the entire memory space required to store the halos*/
+    *halos = mymalloc(sizeof(struct halo_data) * nhalos);
+    XRETURN(*halos != NULL, -MALLOC_FAILURE,
+            "Error: Could not allocate memory for %"PRId64" halos. Size requested = %"PRIu64" bytes\n",
+            nhalos, nhalos * sizeof(struct halo_data));
+
+    struct halo_data *local_halos = *halos;
+
+    // char dataset_name[MAX_STRING_LEN];
+    void *buffer; // Buffer to hold the read HDF5 data.
+    buffer = malloc(nhalos * NDIM * sizeof(double)); // The largest data-type will be double.
+    XRETURN(buffer != NULL, -MALLOC_FAILURE,
+            "Error: Could not allocate memory for %"PRId64" halos in the HDF5 buffer. Size requested = %"PRIu64" bytes\n",
+            nhalos, nhalos * NDIM * sizeof(double));
+
+    const int32_t numfiles_this_forest = g4->num_files_per_forest[forestnr];
+    for(int32_t ifile=0; ifile<numfiles_this_forest;ifile++) {
+        const int32_t fd_index = g4->start_h5_fd_index[forestnr] + ifile;
+        XRETURN(fd_index < g4->numfiles, -1, "Error: Index for HDF5 file pointer = %d should be between [0, %d)\n",
+                fd_index, g4->numfiles);
+        const hid_t fd = g4->open_h5_fds[fd_index];
+        /* CHECK: HDF5 file pointer is valid */
+        XRETURN( fd > 0, -INVALID_FILE_POINTER, "Error: File pointer is NULL (i.e., you need to open the file before reading).\n"
+                "This error should already have been caught before reaching this line\n");
+
+
+        hsize_t nhalo_offset[1] = {0};
+        if(ifile == 0) {
+            nhalo_offset[0] = g4->offset_in_nhalos_first_file_for_forests[forestnr];
+        }
+        // fprintf(stderr,"forestnr = %"PRId64" ifile = %d fd_index = %d (numfiles_this_task=%d) nhalos = %"PRId64" offset = %lld\n",
+        //        forestnr, ifile, fd_index, g4->numfiles, nhalos, nhalo_offset[0]);
+
+        const hsize_t numhalos_this_file[1] = {g4->nhalos_per_file_per_forest[forestnr][ifile]};
+        // fprintf(stderr,"forestnr = %"PRId64" fd = %ld (numfiles = %d) treenum = %"PRId64" nhalos = %"PRId64" nhalos_this_file = %llu\n", 
+        //                forestnr, (long) fd, numfiles_this_forest, treenum_in_file, nhalos, numhalos_this_file[0]);
+
+        /* Merger Tree Pointers */
+        READ_TREE_PROPERTY(fd, nhalo_offset, Descendant, "TreeDescendant", numhalos_this_file, int);
+        READ_TREE_PROPERTY(fd, nhalo_offset, FirstProgenitor, "TreeFirstProgenitor", numhalos_this_file, int);
+        READ_TREE_PROPERTY(fd, nhalo_offset, NextProgenitor, "TreeNextProgenitor", numhalos_this_file, int);
+        READ_TREE_PROPERTY(fd, nhalo_offset, FirstHaloInFOFgroup, "TreeFirstHaloInFOFgroup", numhalos_this_file, int);
+        READ_TREE_PROPERTY(fd, nhalo_offset, NextHaloInFOFgroup, "TreeNextHaloInFOFgroup", numhalos_this_file, int);
+
+        /* Halo Properties */
+        const hsize_t multi_dim_offset[] = {nhalo_offset[0], 0};
+        const hsize_t multi_dim_count[] = {numhalos_this_file[0], 3};
+        READ_TREE_PROPERTY(fd, nhalo_offset, Len, "SubhaloLen", numhalos_this_file, int);
+        // READ_TREE_PROPERTY(fd, nhalo_offset, M_Mean200, Group_M_Mean200, numhalos_this_file, float);//MS: units 10^10 Msun/h for all Illustris mass fields
+        // READ_TREE_PROPERTY(fd, nhalo_offset, M_Mean200, "SubhaloMass", numhalos_this_file, float);//MS: units 10^10 Msun/h for all Illustris mass fields
+        READ_TREE_PROPERTY(fd, nhalo_offset, Mvir, "SubhaloMass", numhalos_this_file, float);//MS: 16/9/2019 sage uses Mvir but assumes that contains M200c
+        // READ_TREE_PROPERTY(fd, nhalo_offset, M_TopHat, Group_M_TopHat200, numhalos_this_file, float);
+        READ_TREE_PROPERTY_MULTIPLEDIM(fd, multi_dim_offset, Pos, "SubhaloPos", 3, multi_dim_count, float);//needs to be converted from kpc/h -> Mpc/h
+        READ_TREE_PROPERTY_MULTIPLEDIM(fd, multi_dim_offset, Vel, "SubhaloVel", 3, multi_dim_count, float);//km/s
+        READ_TREE_PROPERTY(fd, nhalo_offset, VelDisp, "SubhaloVelDisp", numhalos_this_file, float);//km/s
+        READ_TREE_PROPERTY(fd, nhalo_offset, Vmax, "SubhaloVmax", numhalos_this_file, float);//km/s
+        READ_TREE_PROPERTY_MULTIPLEDIM(fd, multi_dim_offset, Spin, "SubhaloSpin", 3, multi_dim_count, float);//(kpc/h)(km/s) -> convert to (Mpc)*(km/s). Does it need sqrt(3)?
+        READ_TREE_PROPERTY(fd, nhalo_offset, MostBoundID, "SubhaloIDMostbound", numhalos_this_file, unsigned int);
+
+        /* File Position Info */
+        READ_TREE_PROPERTY(fd, nhalo_offset, SnapNum, "SnapNum", numhalos_this_file, int);
+        // READ_TREE_PROPERTY(fd, nhalo_offset, FileNr, FileNr, numhalos_this_file, int);
+        READ_TREE_PROPERTY(fd, nhalo_offset, SubhaloIndex, "SubhaloNr", numhalos_this_file, int);//MS: Unsure if this is the right field mapping (another option is SubhaloNumber)
+        //READ_TREE_PROPERTY(fd, nhalo_offset, SubHalfMass, SubHalfMass, numhalos_this_file, float);//MS: Unsure what this field captures -> thankfully unused within sage
+
+        local_halos += numhalos_this_file[0];
+
+    #ifdef DEBUG_HDF5_READER
+        for (int32_t i = 0; i < 20; ++i) {
+            printf("halo %d: Descendant %d FirstProg %d x %.4f y %.4f z %.4f\n", i, local_halos[i].Descendant, local_halos[i].FirstProgenitor, local_halos[i].Pos[0], local_halos[i].Pos[1], local_halos[i].Pos[2]);
+        }
+        ABORT(0);
+    #endif
+    }
+    local_halos -= nhalos;
+
+    free(buffer);
+    int status = convert_units_for_forest(*halos, nhalos, hubble);
+    if(status != EXIT_SUCCESS) {
+        return -1;
+    }
+
+    for(int64_t i=0;i<nhalos;i++) {
+        XRETURN(local_halos[i].FirstProgenitor == -1 || (local_halos[i].FirstProgenitor >= 0 && local_halos[i].FirstProgenitor < nhalos), -1, 
+        "Error: forestnr = %"PRId64" (with nhalos = %"PRId64") for i=%"PRId64" firstprog = %d\n", forestnr, nhalos, i, local_halos[i].FirstProgenitor);
+        XRETURN(local_halos[i].Descendant == -1 || (local_halos[i].Descendant >= 0 && local_halos[i].Descendant < nhalos), -1, 
+        "Error: forestnr = %"PRId64" (with nhalos = %"PRId64") for i=%"PRId64" firstprog = %d\n", forestnr, nhalos, i, local_halos[i].Descendant);
+        XRETURN(local_halos[i].NextProgenitor == -1 || (local_halos[i].NextProgenitor >= 0 && local_halos[i].NextProgenitor < nhalos), -1, 
+        "Error: forestnr = %"PRId64" (with nhalos = %"PRId64") for i=%"PRId64" firstprog = %d\n", forestnr, nhalos, i, local_halos[i].NextProgenitor);
+
+
+        XRETURN(local_halos[i].FirstHaloInFOFgroup >= 0 && local_halos[i].FirstHaloInFOFgroup < nhalos, -1, 
+        "Error: forestnr = %"PRId64" (with nhalos = %"PRId64") for i=%"PRId64" firstprog = %d\n", 
+        forestnr, nhalos, i, local_halos[i].FirstHaloInFOFgroup);
+        XRETURN(local_halos[i].NextHaloInFOFgroup == -1 || (local_halos[i].NextHaloInFOFgroup >= 0 && local_halos[i].NextHaloInFOFgroup < nhalos), -1, 
+        "Error: forestnr = %"PRId64" (with nhalos = %"PRId64") for i=%"PRId64" firstprog = %d\n", forestnr, nhalos, i, local_halos[i].NextHaloInFOFgroup);
+
+        // for(int k=0;k<3;k++) {
+        //     XRETURN(local_halos[i].Pos[k] >= 0 && local_halos[i].Pos[k] <= forests_info->BoxSize, -1, 
+        //     "Error: forestnr = %"PRId64" (with nhalos = %"PRId64" offset = %"PRId64") for i=%"PRId64" pos[%d] = %g original_treenr = %"PRId64" filenr = %d\n", 
+        //     forestnr, nhalos, g4->offset_in_nhalos_first_file_for_forests[forestnr], 
+        //     i, k, local_halos[i].Pos[k], forests_info->original_treenr[forestnr], forests_info->FileNr[forestnr]);
+        // }
+    }
+
+    return nhalos;
+}
+
+#undef READ_TREE_PROPERTY
+#undef READ_TREE_PROPERTY_MULTIPLEDIM
+
+
+int convert_units_for_forest(struct halo_data *halos, const int64_t nhalos, const double hubble)
+{
+    (void ) hubble;
+    if (nhalos <= 0) {
+        fprintf(stderr,"Strange!: In function %s> Got nhalos = %"PRId64". Expected to get nhalos > 0\n", __FUNCTION__, nhalos);
+        return -1;
+    }
+
+    // const float spin_conv_fac = (float) (0.001/hubble);
+
+    /* Any unit conversions or resetting thing that need to be done */
+    for(int64_t i=0;i<nhalos;i++) {
+        halos[i].SubHalfMass = -1.0f;
+        halos[i].FileNr = -1;//FileNr is stored at the forest level and *NOT* the halo level
+    }
+
+    return EXIT_SUCCESS;
+}
+
+
+void cleanup_forests_io_gadget4_hdf5(struct forest_info *forests_info)
+{
+    struct gadget4_info *g4 = &(forests_info->gadget4);
+    // myfree(g4->h5_fd);
+    // const ssize_t nleaks = H5Fget_obj_count(H5F_OBJ_ALL, H5F_OBJ_ALL);
+    // fprintf(stderr,"Should be numfiles = %d for hdf5 nleaks = %zd\n", g4->numfiles, nleaks);
+
+    for(int32_t i=0;i<g4->numfiles;i++) {
+        /* could use 'H5close' instead to make sure any open datasets are also
+           closed; but that would hide potential bugs in code.
+           valgrind should pick those cases up  */
+        H5Fclose(g4->open_h5_fds[i]);
+    }
+    myfree(g4->open_h5_fds);
+    myfree(g4->start_h5_fd_index);
+    myfree(g4->nhalos_per_forest);
+    for(int64_t iforest=0;iforest<g4->nforests;iforest++) {
+        free(g4->nhalos_per_file_per_forest[iforest]);
+    }
+    myfree(g4->nhalos_per_file_per_forest);
+    myfree(g4->offset_in_nhalos_first_file_for_forests);
+    myfree(g4->num_files_per_forest);
+}
+
+int load_tree_table_gadget4_hdf5(const int firstfile, const int lastfile, const int64_t *totnforests_per_file, 
+                                 const struct params *run_params, const int ThisTask, 
+                                 int64_t *nhalos_per_forest)
+{
+    /* The treetable for nhalos per forest is written as 32-bit integers; 
+        however, we really use 64-bit integers. So, we have to split up the work and read
+        in the 32-bit integers into a temporary buffer and then assign 
+        to the parameter *nhalos_per_forest.  */
+    int64_t max_nforests_per_file = 0;
+    int32_t *buffer = NULL;
+    for(int32_t ifile=firstfile;ifile<=lastfile;ifile++) {
+        int64_t nforests_this_file = totnforests_per_file[ifile];
+        if (nforests_this_file > max_nforests_per_file) max_nforests_per_file = nforests_this_file;
+    }
+    buffer = malloc(max_nforests_per_file * sizeof(*buffer));
+    CHECK_POINTER_AND_RETURN_ON_NULL(buffer,
+                                    "Failed to allocate %"PRId64" buffer to hold (32-bit integers, size = %zu) nhalos_per_forest\n", 
+                                    max_nforests_per_file,
+                                    sizeof(*buffer));
+
+    for(int32_t ifile=firstfile;ifile<=lastfile;ifile++) {
+        int64_t nforests_this_file = totnforests_per_file[ifile];
+        if(nforests_this_file == 0) {
+            if(ThisTask == 0 && ifile==firstfile) {
+                fprintf(stderr, "WARNING: The first file = %d does not contain any halos from a *new* tree (i.e., "
+                                "the first file *only* contains halos belonging to a tree that starts in a previous file\n", ifile);
+            }
+            continue;
+        }
+        if(nforests_this_file > max_nforests_per_file) {
+            fprintf(stderr,"Error: The number of forests in this file = %"PRId64" exceeds the max. number of expected forests = %"PRId64"\n",
+                           nforests_this_file, max_nforests_per_file);
+            return -1;
+        }
+
+        char filename[4*MAX_STRING_LEN];
+        get_forests_filename_gadget4_hdf5(filename, 4*MAX_STRING_LEN, ifile, run_params);
+        hid_t fd = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT);
+        XRETURN( fd > 0, FILE_NOT_FOUND,"Error: can't open file `%s'\n", filename);
+
+        /* If we are here, then there *must* be at least one *new* tree that starts in this file 
+            -> the dataset TreeTable *must* exist. (The TreeTable dataset does not exist in files
+            where there are no new trees beginning - only halos from trees that have begun in a previous
+            file and potentially continue to the exact end of this file or beyond this file. - MS 6th June, 2023)
+        */
+
+        char dataset_name[MAX_STRING_LEN];
+        snprintf(dataset_name, MAX_STRING_LEN, "TreeTable/Length");
+        const int check_size = 1;
+        herr_t h5_status = read_dataset(fd, dataset_name, 0, (void *) buffer, sizeof(*buffer), check_size);
+        if(h5_status < 0) {
+            return -1;
+        }
+
+        //Now assign the (32-bit integers) from buffer to the 64-bit nhalos_per_forest
+        for(int64_t j=0;j<nforests_this_file;j++) {
+            nhalos_per_forest[j] = (int64_t) buffer[j];
+        }
+        nhalos_per_forest += nforests_this_file;
+        XRETURN ( H5Fclose(fd) >= 0, -1, "Error: Could not properly close the hdf5 file for filename = '%s'\n", filename);
+    }
+    free(buffer);
+    return EXIT_SUCCESS;
+}

--- a/src/io/read_tree_gadget4_hdf5.c
+++ b/src/io/read_tree_gadget4_hdf5.c
@@ -662,6 +662,8 @@ int64_t load_forest_gadget4_hdf5(const int64_t forestnr, struct halo_data **halo
         return -1;
     }
 
+    /* Since the Gadget4 mergertree is by far the most complicated among all the supported formats,
+        we have this extra validation step within the load routine. MS 29/07/2023 */
     for(int64_t i=0;i<nhalos;i++) {
         XRETURN(local_halos[i].FirstProgenitor == -1 || (local_halos[i].FirstProgenitor >= 0 && local_halos[i].FirstProgenitor < nhalos), -1, 
         "Error: forestnr = %"PRId64" (with nhalos = %"PRId64") for i=%"PRId64" firstprog = %d\n", forestnr, nhalos, i, local_halos[i].FirstProgenitor);

--- a/src/io/read_tree_gadget4_hdf5.h
+++ b/src/io/read_tree_gadget4_hdf5.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* working with c++ compiler */
+
+#include <hdf5.h>
+
+/* for definition of struct halo_data and struct forest_info */
+#include "../core_allvars.h"
+
+    /* Proto-Types */
+    extern int setup_forests_io_gadget4_hdf5(struct forest_info *forests_info,
+                                             const int ThisTask, const int NTasks, struct params *run_params);
+    extern int64_t load_forest_gadget4_hdf5(const int64_t forestnr, struct halo_data **halos, struct forest_info *forests_info, const double hubble);
+    extern void cleanup_forests_io_gadget4_hdf5(struct forest_info *forests_info);
+
+#ifdef __cplusplus
+}
+#endif /* working with c++ compiler */

--- a/src/io/read_tree_gadget4_hdf5.h
+++ b/src/io/read_tree_gadget4_hdf5.h
@@ -4,8 +4,6 @@
 extern "C" {
 #endif /* working with c++ compiler */
 
-#include <hdf5.h>
-
 /* for definition of struct halo_data and struct forest_info */
 #include "../core_allvars.h"
 

--- a/src/io/read_tree_gadget4_hdf5.h
+++ b/src/io/read_tree_gadget4_hdf5.h
@@ -12,7 +12,7 @@ extern "C" {
     /* Proto-Types */
     extern int setup_forests_io_gadget4_hdf5(struct forest_info *forests_info,
                                              const int ThisTask, const int NTasks, struct params *run_params);
-    extern int64_t load_forest_gadget4_hdf5(const int64_t forestnr, struct halo_data **halos, struct forest_info *forests_info, const double hubble);
+    extern int64_t load_forest_gadget4_hdf5(const int64_t forestnr, struct halo_data **halos, struct forest_info *forests_info);
     extern void cleanup_forests_io_gadget4_hdf5(struct forest_info *forests_info);
 
 #ifdef __cplusplus

--- a/src/io/read_tree_lhalo_binary.c
+++ b/src/io/read_tree_lhalo_binary.c
@@ -8,15 +8,20 @@
 #include "read_tree_lhalo_binary.h"
 #include "../core_mymalloc.h"
 #include "../core_utils.h"
-
 #include "forest_utils.h"
 
-/* Externally visible Functions */
+
+static void get_forests_filename_lht_binary(char *filename, const size_t len, const int filenr, const struct params *run_params);
+static int load_tree_table_lht_binary(const int firstfile, const int lastfile, const int64_t *totnforests_per_file, 
+                                      const struct params *run_params, const int ThisTask, 
+                                      int64_t *nhalos_per_forest);
+
 void get_forests_filename_lht_binary(char *filename, const size_t len, const int filenr, const struct params *run_params)
 {
     snprintf(filename, len - 1, "%s/%s.%d%s", run_params->SimulationDir, run_params->TreeName, filenr, run_params->TreeExtension);
 }
 
+/* Externally visible Functions */
 int setup_forests_io_lht_binary(struct forest_info *forests_info,
                                 const int ThisTask, const int NTasks, struct params *run_params)
 {
@@ -29,7 +34,7 @@ int setup_forests_io_lht_binary(struct forest_info *forests_info,
     }
 
     /* wasteful to allocate for lastfile + 1 indices, rather than numfiles; but makes indexing easier */
-    int32_t *totnforests_per_file = calloc(lastfile + 1, sizeof(totnforests_per_file[0]));
+    int64_t *totnforests_per_file = calloc(lastfile + 1, sizeof(totnforests_per_file[0]));
     if(totnforests_per_file == NULL) {
         fprintf(stderr,"Error: Could not allocate memory to store the number of forests in each file\n");
         perror(NULL);
@@ -47,17 +52,35 @@ int setup_forests_io_lht_binary(struct forest_info *forests_info,
             perror(NULL);
             return FILE_NOT_FOUND;
         }
-        mypread(fd, &(totnforests_per_file[filenr]), sizeof(int), 0);
+        int tmp;
+        mypread(fd, &tmp, sizeof(int), 0);
+        totnforests_per_file[filenr] = tmp;
         totnforests += totnforests_per_file[filenr];
 
         close(fd);
     }
     forests_info->totnforests = totnforests;
 
+
+    const int need_nhalos_per_forest = run_params->ForestDistributionScheme == uniform_in_forests ? 0:1;
+    int64_t *nhalos_per_forest = NULL;
+    if(need_nhalos_per_forest) {
+        nhalos_per_forest = mycalloc(totnforests, sizeof(*nhalos_per_forest));
+        int status = load_tree_table_lht_binary(firstfile, lastfile, totnforests_per_file, run_params, ThisTask, nhalos_per_forest);
+        if(status != EXIT_SUCCESS) {
+            return status;
+        }
+    }
+
     int64_t nforests_this_task, start_forestnum;
-    int status = distribute_forests_over_ntasks(totnforests, NTasks, ThisTask, &nforests_this_task, &start_forestnum);
-    if (status != EXIT_SUCCESS) {
+    int status = distribute_weighted_forests_over_ntasks(totnforests, nhalos_per_forest,
+                                                         run_params->ForestDistributionScheme, run_params->Exponent_Forest_Dist_Scheme,
+                                                         NTasks, ThisTask, &nforests_this_task, &start_forestnum);
+    if(status != EXIT_SUCCESS) {
         return status;
+    }
+    if(need_nhalos_per_forest) {
+        free(nhalos_per_forest);
     }
 
     const int64_t end_forestnum = start_forestnum + nforests_this_task; /* not inclusive, i.e., do not process forestnr == end_forestnum */
@@ -89,77 +112,37 @@ int setup_forests_io_lht_binary(struct forest_info *forests_info,
         return MALLOC_FAILURE;
     }
 
-    /* show no forests need to be processed by default */
-    for(int i=0;i<=lastfile;i++) {
-        start_forestnum_to_process_per_file[i] = -1;
-    }
-
     // Now for each task, we know the starting forest number it needs to start reading from.
     // So let's determine what file and forest number within the file each task needs to start/end reading from.
     int start_filenum = -1, end_filenum = -1;
-    int64_t nforests_so_far = 0;
-    for(int filenr=firstfile;filenr<=lastfile;filenr++) {
-        const int32_t nforests_this_file = totnforests_per_file[filenr];
-        const int64_t end_forestnum_this_file = nforests_so_far + nforests_this_file;
-        start_forestnum_to_process_per_file[filenr] = 0;
-        num_forests_to_process_per_file[filenr] = nforests_this_file;
-
-        /* Check if this task should be reading from this file (referred by filenr)
-           If the starting forest number (start_forestnum, which is cumulative across all files)
-           is located within this file, then the task will need to read from this file.
-         */
-        if(start_forestnum >= nforests_so_far && start_forestnum < end_forestnum_this_file) {
-            start_filenum = filenr;
-            start_forestnum_to_process_per_file[filenr] = start_forestnum - nforests_so_far;
-            num_forests_to_process_per_file[filenr] = nforests_this_file - (start_forestnum - nforests_so_far);
-        }
-
-        /* Similar to above, if the end forst number (end_forestnum, again cumulative across all files)
-           is located with this file, then the task will need to read from this file.
-        */
-
-        if(end_forestnum >= nforests_so_far && end_forestnum <= end_forestnum_this_file) {
-            end_filenum = filenr;
-
-            // In the scenario where this task reads ALL forests from a single file, then the number
-            // of forests read from this file will be the number of forests assigned to it.
-            if(end_filenum == start_filenum) {
-                num_forests_to_process_per_file[filenr] = nforests_this_task;
-            } else {
-                num_forests_to_process_per_file[filenr] = end_forestnum - nforests_so_far;
-            }
-            /* MS & JS: 07/03/2019 -- Probably okay to break here but might need to complete loop for validation */
-        }
-        nforests_so_far += nforests_this_file;
+    status = find_start_and_end_filenum(start_forestnum, end_forestnum, 
+                                        totnforests_per_file, totnforests, 
+                                        firstfile, lastfile,
+                                        ThisTask, NTasks, 
+                                        // NULL, 
+                                        num_forests_to_process_per_file, start_forestnum_to_process_per_file,
+                                        &start_filenum, &end_filenum);
+    if(status != EXIT_SUCCESS) {
+        return status;
     }
 
-    // Make sure we found a file to start/end reading for this task.
-    if(start_filenum == -1 || end_filenum == -1 ) {
-        fprintf(stderr,"Error: Could not locate start or end file number for the lhalotree binary files\n");
-        fprintf(stderr,"Printing debug info\n");
-        fprintf(stderr,"ThisTask = %d NTasks = %d totnforests = %"PRId64" start_forestnum = %"PRId64" nforests_this_task = %"PRId64"\n",
-                ThisTask, NTasks, totnforests, start_forestnum, nforests_this_task);
-        for(int filenr=firstfile;filenr<=lastfile;filenr++) {
-            fprintf(stderr,"filenr := %d contains %d forests\n",filenr, totnforests_per_file[filenr]);
-        }
 
-        return -1;
-    }
     lht->numfiles = end_filenum - start_filenum + 1;
     lht->open_fds = mymalloc(lht->numfiles * sizeof(lht->open_fds[0]));
 
-    int32_t *forestnhalos = lht->nhalos_per_forest;
+    int64_t *forestnhalos = lht->nhalos_per_forest;
+    int64_t nforests_so_far = 0;
     for(int filenr=start_filenum;filenr<=end_filenum;filenr++) {
         XRETURN(start_forestnum_to_process_per_file[filenr] >= 0 && start_forestnum_to_process_per_file[filenr] < totnforests_per_file[filenr],
                 EXIT_FAILURE,
-                "Error: Num forests to process = %"PRId64" for filenr = %d should be in range [0, %d)\n",
+                "Error: Num forests to process = %"PRId64" for filenr = %d should be in range [0, %"PRId64")\n",
                 start_forestnum_to_process_per_file[filenr],
                 filenr,
                 totnforests_per_file[filenr]);
 
         XRETURN(num_forests_to_process_per_file[filenr] >= 0 && num_forests_to_process_per_file[filenr] <= totnforests_per_file[filenr],
                 EXIT_FAILURE,
-                "Error: Num forests to process = %"PRId64" for filenr = %d should be in range [0, %d)\n",
+                "Error: Num forests to process = %"PRId64" for filenr = %d should be in range [0, %"PRId64")\n",
                 num_forests_to_process_per_file[filenr],
                 filenr,
                 totnforests_per_file[filenr]);
@@ -174,10 +157,10 @@ int setup_forests_io_lht_binary(struct forest_info *forests_info,
 
         const int64_t nforests_to_process_this_file = num_forests_to_process_per_file[filenr];
         const size_t nbytes = totnforests_per_file[filenr] * sizeof(int32_t);
-        int32_t *nhalos_per_forest = malloc(nbytes);
+        nhalos_per_forest = malloc(nbytes);
         XRETURN(nhalos_per_forest != NULL, MALLOC_FAILURE,
                 "Error: Could not allocate memory to read nhalos per forest. Bytes requested = %zu\n", nbytes);
-
+        
         mypread(fd, nhalos_per_forest, nbytes, 8); /* the last argument says to start after sizeof(totntrees) + sizeof(totnhalos) */
         memcpy(forestnhalos, &(nhalos_per_forest[start_forestnum_to_process_per_file[filenr]]), nforests_to_process_this_file * sizeof(forestnhalos[0]));
 
@@ -289,4 +272,58 @@ void cleanup_forests_io_lht_binary(struct forest_info *forests_info)
         close(lht->open_fds[i]);
     }
     myfree(lht->open_fds);
+}
+
+int load_tree_table_lht_binary(const int firstfile, const int lastfile, const int64_t *totnforests_per_file, 
+                                 const struct params *run_params, const int ThisTask, 
+                                 int64_t *nhalos_per_forest)
+{
+    /* The nhalos_per_forest array is written as 32-bit integers; 
+        however, we really use 64-bit integers. So, we have to split up the work and read
+        in the 32-bit integers into a temporary buffer and then assign 
+        to the parameter *nhalos_per_forest.  */
+    int64_t max_nforests_per_file = 0;
+    int32_t *buffer = NULL;
+    for(int32_t ifile=firstfile;ifile<=lastfile;ifile++) {
+        int64_t nforests_this_file = totnforests_per_file[ifile];
+        if (nforests_this_file > max_nforests_per_file) max_nforests_per_file = nforests_this_file;
+    }
+    buffer = malloc(max_nforests_per_file * sizeof(*buffer));
+    CHECK_POINTER_AND_RETURN_ON_NULL(buffer,
+                                    "Failed to allocate %"PRId64" buffer to hold (32-bit integers, size = %zu) nhalos_per_forest\n", 
+                                    max_nforests_per_file,
+                                    sizeof(*buffer));
+
+    for(int32_t ifile=firstfile;ifile<=lastfile;ifile++) {
+        int64_t nforests_this_file = totnforests_per_file[ifile];
+        if(nforests_this_file == 0) {
+            if(ThisTask == 0 && ifile==firstfile) {
+                fprintf(stderr, "WARNING: The first file = %d does not contain any halos from a *new* tree (i.e., "
+                                "the first file *only* contains halos belonging to a tree that starts in a previous file\n", ifile);
+            }
+            continue;
+        }
+        if(nforests_this_file > max_nforests_per_file) {
+            fprintf(stderr,"Error: The number of forests in this file = %"PRId64" exceeds the max. number of expected forests = %"PRId64"\n",
+                           nforests_this_file, max_nforests_per_file);
+            return -1;
+        }
+
+        char filename[4*MAX_STRING_LEN];
+        get_forests_filename_lht_binary(filename, 4*MAX_STRING_LEN, ifile, run_params);
+        int fd = open(filename, O_RDONLY);
+        XRETURN( fd > 0, FILE_NOT_FOUND,"Error: can't open file `%s'\n", filename);
+
+        //the last argument is the offset for nhalos_per_forest -> the first 4 bytes
+        //are for totnforests, and the next 4 bytes are for totnhalos, after that 
+        //the nhalos_per_forest[totnforests] starts.
+        mypread(fd, buffer, sizeof(*buffer)*nforests_this_file, 8);
+        for(int64_t i=0;i<nforests_this_file;i++) {
+            nhalos_per_forest[i] = (int64_t) buffer[i];
+        }
+        nhalos_per_forest += nforests_this_file;
+        XRETURN ( close(fd) >= 0, -1, "Error: Could not properly close the binary file for filename = '%s'\n", filename);
+    }
+    free(buffer);
+    return EXIT_SUCCESS;
 }

--- a/src/io/read_tree_lhalo_binary.c
+++ b/src/io/read_tree_lhalo_binary.c
@@ -163,10 +163,11 @@ int setup_forests_io_lht_binary(struct forest_info *forests_info,
                 "Error: Could not allocate memory to read nhalos per forest. Bytes requested = %zu\n", nbytes);
         
         mypread(fd, buffer, nbytes, 8); /* the last argument says to start after sizeof(totntrees) + sizeof(totnhalos) */
+        buffer += start_forestnum_to_process_per_file[filenr];
         for(int k=0;k<nforests_to_process_this_file;k++) {
-            forestnhalos[k] = buffer[k + start_forestnum_to_process_per_file[filenr]];
+            forestnhalos[k] = buffer[k];
         }
-        // memcpy(forestnhalos, &(nhalos_per_forest[start_forestnum_to_process_per_file[filenr]]), nforests_to_process_this_file * sizeof(forestnhalos[0]));
+        buffer -= start_forestnum_to_process_per_file[filenr];
 
         /* first compute the byte offset to the halos in start_forestnum */
         size_t byte_offset_to_halos = sizeof(int32_t) + sizeof(int32_t) + nbytes;/* start at the beginning of halo #0 in tree #0 */

--- a/src/io/read_tree_lhalo_binary.h
+++ b/src/io/read_tree_lhalo_binary.h
@@ -9,7 +9,6 @@ extern "C" {
 #include "../core_allvars.h"
 
     /* Proto-Types */
-    extern void get_forests_filename_lht_binary(char *filename, const size_t len, const int filenr, const struct params *run_params);
     extern int setup_forests_io_lht_binary(struct forest_info *forests_info,
                                            const int ThisTask, const int NTasks, struct params *run_params);
     extern int64_t load_forest_lht_binary(const int64_t forestnr, struct halo_data **halos, struct forest_info *forests_info);

--- a/src/io/read_tree_lhalo_hdf5.c
+++ b/src/io/read_tree_lhalo_hdf5.c
@@ -299,7 +299,7 @@ int setup_forests_io_lht_hdf5(struct forest_info *forests_info,
     }
 
 
-int64_t load_forest_lht_hdf5(const int64_t forestnr, struct halo_data **halos, struct forest_info *forests_info, const double hubble)
+int64_t load_forest_lht_hdf5(const int64_t forestnr, struct halo_data **halos, struct forest_info *forests_info)
 {
     char dataset_name[MAX_STRING_LEN];
     void *buffer; // Buffer to hold the read HDF5 data.

--- a/src/io/read_tree_lhalo_hdf5.c
+++ b/src/io/read_tree_lhalo_hdf5.c
@@ -14,7 +14,7 @@
 #include "forest_utils.h"
 
 /* Local Proto-Types */
-static int convert_units_for_forest(struct halo_data *halos, const int64_t nhalos, const double hubble);
+static int convert_units_for_forest(struct halo_data *halos, const int64_t nhalos);
 static void get_forests_filename_lht_hdf5(char *filename, const size_t len, const int filenr, const struct params *run_params);
 
 
@@ -384,7 +384,7 @@ int64_t load_forest_lht_hdf5(const int64_t forestnr, struct halo_data **halos, s
     ABORT(0);
 #endif
 
-    status = convert_units_for_forest(*halos, nhalos, hubble);
+    status = convert_units_for_forest(*halos, nhalos);
     if(status != EXIT_SUCCESS) {
         return -1;
     }
@@ -395,20 +395,20 @@ int64_t load_forest_lht_hdf5(const int64_t forestnr, struct halo_data **halos, s
 #undef READ_TREE_PROPERTY
 #undef READ_TREE_PROPERTY_MULTIPLEDIM
 
-
-int convert_units_for_forest(struct halo_data *halos, const int64_t nhalos, const double hubble)
+int convert_units_for_forest(struct halo_data *halos, const int64_t nhalos)
 {
-    const float spin_conv_fac = (float) (0.001/hubble);
     if (nhalos <= 0) {
         fprintf(stderr,"Strange!: In function %s> Got nhalos = %"PRId64". Expected to get nhalos > 0\n", __FUNCTION__, nhalos);
         return -1;
     }
 
+    // const float spin_conv_fac = (float) (0.001/hubble);
+    const float spin_conv_fac = 0.001f; //As pointed out in https://github.com/sage-home/sage-model/issues/46, scaling with h is not required
     /* Any unit conversions or resetting thing that need to be done */
     for(int64_t i=0;i<nhalos;i++) {
         for(int j=0;j<3;j++) {
-            halos[i].Pos[j] *= 0.001f;//convert from kpc -> Mpc
-            halos[i].Spin[j] *= spin_conv_fac;//convert from (kpc/h)*(km/s) -> (Mpc)*(km/s)
+            halos[i].Pos[j] *= 0.001f;//convert from kpc/h -> Mpc/h
+            halos[i].Spin[j] *= spin_conv_fac;//convert from (kpc/h)*(km/s) -> (Mpc/h)*(km/s)
         }
         halos[i].SubhaloIndex = -1;
         halos[i].SubHalfMass = -1.0f;
@@ -416,7 +416,6 @@ int convert_units_for_forest(struct halo_data *halos, const int64_t nhalos, cons
 
     return EXIT_SUCCESS;
 }
-
 
 void cleanup_forests_io_lht_hdf5(struct forest_info *forests_info)
 {

--- a/src/io/read_tree_lhalo_hdf5.c
+++ b/src/io/read_tree_lhalo_hdf5.c
@@ -11,20 +11,9 @@
 #include "read_tree_lhalo_hdf5.h"
 #include "hdf5_read_utils.h"
 #include "../core_mymalloc.h"
-
-
-/* Local Structs */
-struct METADATA_NAMES
-{
-    char name_NTrees[MAX_STRING_LEN];
-    char name_totNHalos[MAX_STRING_LEN];
-    char name_TreeNHalos[MAX_STRING_LEN];
-    char name_ParticleMass[MAX_STRING_LEN];
-    char name_NumSimulationTreeFiles[MAX_STRING_LEN];
-};
+#include "forest_utils.h"
 
 /* Local Proto-Types */
-static int32_t fill_metadata_names(struct METADATA_NAMES *metadata_names, enum Valid_TreeTypes my_TreeType);
 static int convert_units_for_forest(struct halo_data *halos, const int64_t nhalos, const double hubble);
 static void get_forests_filename_lht_hdf5(char *filename, const size_t len, const int filenr, const struct params *run_params);
 
@@ -46,13 +35,13 @@ int setup_forests_io_lht_hdf5(struct forest_info *forests_info,
     }
 
     /* wasteful to allocate for lastfile + 1 indices, rather than numfiles; but makes indexing easier */
-    int32_t *totnforests_per_file = calloc(lastfile + 1, sizeof(totnforests_per_file[0]));
+    int64_t *totnforests_per_file = calloc(lastfile + 1, sizeof(*totnforests_per_file));
     if(totnforests_per_file == NULL) {
         fprintf(stderr,"Error: Could not allocate memory to store the number of forests in each file\n");
         perror(NULL);
         return MALLOC_FAILURE;
     }
-    struct METADATA_NAMES metadata_names;
+    struct HDF5_METADATA_NAMES metadata_names;
     int64_t totnforests = 0;
     for(int filenr=firstfile;filenr<=lastfile;filenr++) {
         char filename[4*MAX_STRING_LEN];
@@ -61,7 +50,7 @@ int setup_forests_io_lht_hdf5(struct forest_info *forests_info,
         XRETURN (fd > 0, FILE_NOT_FOUND,
                  "Error: can't open file `%s'\n", filename);
 
-        int status = fill_metadata_names(&metadata_names, run_params->TreeType);
+        int status = fill_hdf5_metadata_names(&metadata_names, run_params->TreeType);
         if (status != EXIT_SUCCESS) {
             return -1;
         }
@@ -115,24 +104,50 @@ int setup_forests_io_lht_hdf5(struct forest_info *forests_info,
     }
     forests_info->totnforests = totnforests;
 
-    const int64_t nforests_per_cpu = (int64_t) (totnforests/NTasks);
-    const int64_t rem_nforests = totnforests % NTasks;
-    int64_t nforests_this_task = nforests_per_cpu;
-    if(ThisTask < rem_nforests) {
-        nforests_this_task++;
+
+    /* Read in nhalos_per_forest for *ALL* files */
+    const int need_nhalos_per_forest = run_params->ForestDistributionScheme == uniform_in_forests ? 0:1;
+    int64_t *nhalos_per_forest = NULL;
+    if(need_nhalos_per_forest) {
+        nhalos_per_forest = mycalloc(totnforests, sizeof(*nhalos_per_forest));
+        for(int32_t ifile=firstfile;ifile<=lastfile;ifile++) {
+            const int64_t nforests_this_file = totnforests_per_file[ifile];
+            char filename[4*MAX_STRING_LEN];
+            get_forests_filename_lht_hdf5(filename, 4*MAX_STRING_LEN, ifile, run_params);
+            hid_t fd = H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT);
+            XRETURN (fd > 0, FILE_NOT_FOUND,
+                     "Error: can't open file `%s'\n", filename);
+
+            const int check_size = 1;
+            int32_t *buffer = NULL;
+            int status = read_dataset(fd, metadata_names.name_TreeNHalos, -1, (void *) buffer, sizeof(*buffer), check_size);
+            if(status < 0) {
+                return status;
+            }
+            for(int64_t i=0;i<nforests_this_file;i++) {
+                nhalos_per_forest[i] = buffer[i];
+            }
+            XRETURN( H5Fclose(fd) > 0, -1, "Error: Could not properly close the hdf5 file for filename = '%s'\n", filename);
+
+            nhalos_per_forest += nforests_this_file;
+        }
+        //Move back the pointer to the allocated address
+        nhalos_per_forest -= totnforests;
     }
 
-    int64_t start_forestnum = nforests_per_cpu * ThisTask;
-    /* Add in the remainder forests that also need to be processed
-       equivalent to the loop
-
-       for(int task=0;task<ThisTask;task++) {
-           if(task < rem_nforests) start_forestnum++;
-       }
-
-     */
-    start_forestnum += ThisTask <= rem_nforests ? ThisTask:rem_nforests; /* assumes that "0<= ThisTask < NTasks" */
+    int64_t nforests_this_task, start_forestnum;
+    int status = distribute_weighted_forests_over_ntasks(totnforests, nhalos_per_forest,
+                                                         run_params->ForestDistributionScheme, run_params->Exponent_Forest_Dist_Scheme,
+                                                         NTasks, ThisTask, &nforests_this_task, &start_forestnum);
+    if(status != EXIT_SUCCESS) {
+        return status;
+    }
+    if(need_nhalos_per_forest) {
+        free(nhalos_per_forest);
+    }
     const int64_t end_forestnum = start_forestnum + nforests_this_task; /* not inclusive, i.e., do not process forestnr == end_forestnum */
+    /* fprintf(stderr,"Thistask = %d start_forestnum = %"PRId64" end_forestnum = %"PRId64"\n", ThisTask, start_forestnum, end_forestnum); */
+
 
     int64_t *num_forests_to_process_per_file = calloc((lastfile + 1), sizeof(num_forests_to_process_per_file[0]));/* calloc is required */
     int64_t *start_forestnum_to_process_per_file = malloc((lastfile + 1) * sizeof(start_forestnum_to_process_per_file[0]));
@@ -142,44 +157,19 @@ int setup_forests_io_lht_hdf5(struct forest_info *forests_info,
         return MALLOC_FAILURE;
     }
 
-    /* show no forests need to be processed by default */
-    for(int i=0;i<=lastfile;i++) {
-        start_forestnum_to_process_per_file[i] = -1;
-        num_forests_to_process_per_file[i] = 0;
-    }
 
+    // Now for each task, we know the starting forest number it needs to start reading from.
+    // So let's determine what file and forest number within the file each task needs to start/end reading from.
     int start_filenum = -1, end_filenum = -1;
-    int64_t nforests_so_far = 0;
-    for(int filenr=firstfile;filenr<=lastfile;filenr++) {
-        const int32_t nforests_this_file = totnforests_per_file[filenr];
-        const int64_t end_forestnum_this_file = nforests_so_far + nforests_this_file;
-        start_forestnum_to_process_per_file[filenr] = 0;
-        num_forests_to_process_per_file[filenr] = nforests_this_file;
-
-        if(start_forestnum >= nforests_so_far && start_forestnum < end_forestnum_this_file) {
-            start_filenum = filenr;
-            start_forestnum_to_process_per_file[filenr] = start_forestnum - nforests_so_far;
-            num_forests_to_process_per_file[filenr] = nforests_this_file - (start_forestnum - nforests_so_far);
-        }
-
-
-        if(end_forestnum >= nforests_so_far && end_forestnum <= end_forestnum_this_file) {
-            end_filenum = filenr;
-            num_forests_to_process_per_file[filenr] = end_forestnum - nforests_so_far;/* does this need a + 1? */
-        }
-        nforests_so_far += nforests_this_file;
-    }
-
-    if(start_filenum == -1 || end_filenum == -1 ) {
-        fprintf(stderr,"Error: Could not locate start or end file number for the lhalotree binary files\n");
-        fprintf(stderr,"Printing debug info\n");
-        fprintf(stderr,"ThisTask = %d NTasks = %d totnforests = %"PRId64" start_forestnum = %"PRId64" nforests_this_task = %"PRId64"\n",
-                ThisTask, NTasks, totnforests, start_forestnum, nforests_this_task);
-        for(int filenr=firstfile;filenr<=lastfile;filenr++) {
-            fprintf(stderr,"filenr := %d contains %d forests\n",filenr, totnforests_per_file[filenr]);
-        }
-
-        return -1;
+    status = find_start_and_end_filenum(start_forestnum, end_forestnum, 
+                                        totnforests_per_file, totnforests, 
+                                        firstfile, lastfile,
+                                        ThisTask, NTasks, 
+                                        // NULL,
+                                        num_forests_to_process_per_file, start_forestnum_to_process_per_file,
+                                        &start_filenum, &end_filenum);
+    if(status != EXIT_SUCCESS) {
+        return status;
     }
 
     struct lhalotree_info *lht = &(forests_info->lht);
@@ -204,19 +194,19 @@ int setup_forests_io_lht_hdf5(struct forest_info *forests_info,
     lht->numfiles = end_filenum - start_filenum + 1;
     lht->open_h5_fds = mymalloc(lht->numfiles * sizeof(lht->open_h5_fds[0]));
 
-    nforests_so_far = 0;
+    int64_t nforests_so_far = 0;
     /* int *forestnhalos = lht->nhalos_per_forest; */
     for(int filenr=start_filenum;filenr<=end_filenum;filenr++) {
         XRETURN(start_forestnum_to_process_per_file[filenr] >= 0 && start_forestnum_to_process_per_file[filenr] < totnforests_per_file[filenr],
                 EXIT_FAILURE,
-                "Error: Num forests to process = %"PRId64" for filenr = %d should be in range [0, %d)\n",
+                "Error: Num forests to process = %"PRId64" for filenr = %d should be in range [0, %"PRId64")\n",
                 start_forestnum_to_process_per_file[filenr],
                 filenr,
                 totnforests_per_file[filenr]);
 
         XRETURN(num_forests_to_process_per_file[filenr] >= 0 && num_forests_to_process_per_file[filenr] <= totnforests_per_file[filenr],
                 EXIT_FAILURE,
-                "Error: Num forests to process = %"PRId64" for filenr = %d should be in range [0, %d)\n",
+                "Error: Num forests to process = %"PRId64" for filenr = %d should be in range [0, %"PRId64")\n",
                 num_forests_to_process_per_file[filenr],
                 filenr,
                 totnforests_per_file[filenr]);
@@ -439,31 +429,4 @@ void cleanup_forests_io_lht_hdf5(struct forest_info *forests_info)
         H5Fclose(lht->open_h5_fds[i]);
     }
     myfree(lht->open_h5_fds);
-}
-
-
-/* Local Functions */
-static int32_t fill_metadata_names(struct METADATA_NAMES *metadata_names, enum Valid_TreeTypes my_TreeType)
-{
-    switch (my_TreeType) {
-    case lhalo_hdf5:
-        snprintf(metadata_names->name_NTrees, MAX_STRING_LEN - 1, "NtreesPerFile"); // Total number of forests within the file.
-        snprintf(metadata_names->name_totNHalos, MAX_STRING_LEN - 1, "NhalosPerFile"); // Total number of halos within the file.
-        snprintf(metadata_names->name_TreeNHalos, MAX_STRING_LEN - 1, "TreeNHalos"); // Number of halos per forest within the file.
-        snprintf(metadata_names->name_ParticleMass, MAX_STRING_LEN - 1, "ParticleMass");//Particle mass for Dark matter in the sim
-        snprintf(metadata_names->name_NumSimulationTreeFiles, MAX_STRING_LEN - 1, "NumberOfOutputFiles");//Particle mass for Dark matter in the sim
-        return EXIT_SUCCESS;
-
-    case lhalo_binary:
-        fprintf(stderr, "If the file is binary then this function should never be called.  Something's gone wrong...");
-        return EXIT_FAILURE;
-
-    default:
-        fprintf(stderr, "Your tree type has not been included in the switch statement for ``%s`` in file ``%s``.\n", __FUNCTION__, __FILE__);
-        fprintf(stderr, "Please add it there.\n");
-        return EXIT_FAILURE;
-
-    }
-
-    return EXIT_FAILURE;
 }

--- a/src/io/read_tree_lhalo_hdf5.h
+++ b/src/io/read_tree_lhalo_hdf5.h
@@ -12,7 +12,7 @@ extern "C" {
     /* Proto-Types */
     extern int setup_forests_io_lht_hdf5(struct forest_info *forests_info,
                                          const int ThisTask, const int NTasks, struct params *run_params);
-    extern int64_t load_forest_lht_hdf5(const int64_t forestnr, struct halo_data **halos, struct forest_info *forests_info, const double hubble);
+    extern int64_t load_forest_lht_hdf5(const int64_t forestnr, struct halo_data **halos, struct forest_info *forests_info);
     extern void cleanup_forests_io_lht_hdf5(struct forest_info *forests_info);
 
 #ifdef __cplusplus

--- a/src/io/save_gals_binary.c
+++ b/src/io/save_gals_binary.c
@@ -138,7 +138,7 @@ int32_t save_binary_galaxies(const int32_t task_treenr, const int32_t num_gals, 
         const size_t numbytes = sizeof(struct GALAXY_OUTPUT)*OutputGalCount[snap_idx];
 
 #ifdef USE_BUFFERED_WRITE
-        status = write_bufferd_io(&all_buffers[snap_idx], galaxy_output, numbytes);
+        status = write_buffered_io(&all_buffers[snap_idx], galaxy_output, numbytes);
         if(status < 0) {
             fprintf(stderr,"Error: Could not write (buffered). snapshot number = %d number of bytes = %zu\n", snap_idx, numbytes);
             return status;

--- a/src/io/save_gals_binary.c
+++ b/src/io/save_gals_binary.c
@@ -172,7 +172,7 @@ int32_t finalize_binary_galaxy_files(const struct forest_info *forest_info, stru
                                         "Error trying to write to output number %d.\nThe file handle is %d.\n",
                                         snap_idx, save_info->save_fd[snap_idx]);
 #ifdef USE_BUFFERED_WRITE
-        int status = cleanup(&all_buffers[snap_idx]);
+        int status = cleanup_buffered_io(&all_buffers[snap_idx]);
         if(status != EXIT_SUCCESS) {
             fprintf(stderr,"Error: Could not finalise the output file for snapshot = %d\n", snap_idx);
             return status;

--- a/src/io/save_gals_binary.c
+++ b/src/io/save_gals_binary.c
@@ -11,10 +11,16 @@
 #include "../core_utils.h"
 #include "../model_misc.h"
 
+#ifdef USE_BUFFERED_WRITE
+#include "buffered_io.h"
+static struct buffered_io *all_buffers = NULL;
+#endif
+
+
 // Local Proto-Types //
 
-int32_t prepare_galaxy_for_output(struct GALAXY *g, struct GALAXY_OUTPUT *o, struct halo_data *halos,
-                                  const int32_t original_treenr, const struct params *run_params);
+static int32_t prepare_galaxy_for_output(struct GALAXY *g, struct GALAXY_OUTPUT *o, struct halo_data *halos,
+                                         const int32_t original_treenr, const struct params *run_params);
 
 // Externally Visible Functions //
 
@@ -22,7 +28,8 @@ int32_t initialize_binary_galaxy_files(const int filenr, const struct forest_inf
                                        const struct params *run_params)
 {
 
-    int32_t ntrees = forest_info->nforests_this_task;
+    const int32_t ntrees = forest_info->nforests_this_task;
+    const off_t halo_data_start_offset = (ntrees + 2) * sizeof(int32_t);
 
     // We open up files for each output. We'll store the file IDs of each of these file.
     save_info->save_fd = mymalloc(run_params->NumSnapOutputs * sizeof(int32_t));
@@ -40,12 +47,26 @@ int32_t initialize_binary_galaxy_files(const int filenr, const struct forest_inf
                                         "Can't open file %s for initialization.\n", buffer);
 
         // write out placeholders for the header data.
-        const off_t off = (ntrees + 2) * sizeof(int32_t);
-        const off_t status = lseek(save_info->save_fd[n], off, SEEK_SET);
+        const off_t status = lseek(save_info->save_fd[n], halo_data_start_offset, SEEK_SET);
         CHECK_STATUS_AND_RETURN_ON_FAIL(status, FILE_WRITE_ERROR,
                                         "Error: Failed to write out %d elements for header information for file %d.\n"
-                                        "Attempted to write %"PRId64" bytes\n", ntrees + 2, n, off);
+                                        "Attempted to write %"PRId64" bytes\n", ntrees + 2, n, halo_data_start_offset);
     }
+
+#ifdef USE_BUFFERED_WRITE
+    const size_t buffer_size = 8 * 1024 * 1024; //8 MB
+    all_buffers = malloc(sizeof(*all_buffers)*run_params->NumSnapOutputs);
+    XRETURN(all_buffers != NULL, -1, "Error: Could not allocate %d elements of size %zu bytes for buffered io\n", 
+                                                      run_params->NumSnapOutputs, sizeof(*all_buffers));
+    for(int n = 0; n < run_params->NumSnapOutputs; n++) {
+        int fd = save_info->save_fd[n];
+        int status = setup_buffered_io(&all_buffers[n], buffer_size, fd, halo_data_start_offset);
+        if(status != EXIT_SUCCESS) {
+            fprintf(stderr,"Error: Could not setup buffered io\n");
+            return -1;
+        }   
+    }
+#endif
 
     return EXIT_SUCCESS;
 }
@@ -114,15 +135,25 @@ int32_t save_binary_galaxies(const int32_t task_treenr, const int32_t num_gals, 
         struct GALAXY_OUTPUT *galaxy_output = all_outputgals + cumul_output_ngal[snap_idx];
 
         // Then write out the chunk of galaxies for this redshift output.
-        ssize_t nwritten = mywrite(save_info->save_fd[snap_idx], galaxy_output, sizeof(struct GALAXY_OUTPUT)*OutputGalCount[snap_idx]);
-        if (nwritten != (ssize_t) (sizeof(struct GALAXY_OUTPUT)*OutputGalCount[snap_idx])) {
+        const size_t numbytes = sizeof(struct GALAXY_OUTPUT)*OutputGalCount[snap_idx];
+
+#ifdef USE_BUFFERED_WRITE
+        status = write_bufferd_io(&all_buffers[snap_idx], galaxy_output, numbytes);
+        if(status < 0) {
+            fprintf(stderr,"Error: Could not write (buffered). snapshot number = %d number of bytes = %zu\n", snap_idx, numbytes);
+            return status;
+        }
+#else
+        ssize_t nwritten = mywrite(save_info->save_fd[snap_idx], galaxy_output, numbytes);
+        if (nwritten != (ssize_t) numbytes) {
             fprintf(stderr, "Error: Failed to write out the galaxy struct for galaxies within file %d. "
                             "Meant to write out %d elements with a total of %zu bytes (%zu bytes for each element). "
                             "However, I wrote out a total of %zd bytes.\n",
-                            snap_idx, OutputGalCount[snap_idx], sizeof(struct GALAXY_OUTPUT)*OutputGalCount[snap_idx], sizeof(struct GALAXY_OUTPUT),
+                            snap_idx, OutputGalCount[snap_idx], numbytes, sizeof(struct GALAXY_OUTPUT),
                             nwritten);
             return FILE_WRITE_ERROR;
         }
+#endif
     }
     myfree(all_outputgals);
     myfree(cumul_output_ngal);
@@ -138,8 +169,15 @@ int32_t finalize_binary_galaxy_files(const struct forest_info *forest_info, stru
     for(int32_t snap_idx = 0; snap_idx < run_params->NumSnapOutputs; snap_idx++) {
         // File must already be open.
         CHECK_STATUS_AND_RETURN_ON_FAIL(save_info->save_fd[snap_idx], EXIT_FAILURE,
-                                        "Error trying to write to output number %d.\nThe save pointer is %d.\n",
+                                        "Error trying to write to output number %d.\nThe file handle is %d.\n",
                                         snap_idx, save_info->save_fd[snap_idx]);
+#ifdef USE_BUFFERED_WRITE
+        int status = cleanup(&all_buffers[snap_idx]);
+        if(status != EXIT_SUCCESS) {
+            fprintf(stderr,"Error: Could not finalise the output file for snapshot = %d\n", snap_idx);
+            return status;
+        }
+#endif
 
         // Write the header data.
         int32_t nwritten = mypwrite(save_info->save_fd[snap_idx], &ntrees, sizeof(ntrees), 0);
@@ -176,6 +214,10 @@ int32_t finalize_binary_galaxy_files(const struct forest_info *forest_info, stru
     }
 
     myfree(save_info->save_fd);
+
+#ifdef USE_BUFFERED_WRITE
+    free(all_buffers);
+#endif
 
     return EXIT_SUCCESS;
 }

--- a/src/io/save_gals_hdf5.c
+++ b/src/io/save_gals_hdf5.c
@@ -217,10 +217,10 @@ int32_t initialize_hdf5_galaxy_files(const int filenr, struct save_info *save_in
         hsize_t dims[1] = {0};
         hsize_t maxdims[1] = {H5S_UNLIMITED};
         hsize_t chunk_dims[1] = {NUM_GALS_PER_BUFFER};
-        char full_field_name[MAX_STRING_LEN];
+        char full_field_name[2*MAX_STRING_LEN];
 
         // Create a snapshot group.
-        snprintf(full_field_name, MAX_STRING_LEN - 1, "Snap_%d", run_params->ListOutputSnaps[snap_idx]);
+        snprintf(full_field_name, 2*MAX_STRING_LEN - 1, "Snap_%d", run_params->ListOutputSnaps[snap_idx]);
         hid_t group_id = H5Gcreate2(file_id, full_field_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         CHECK_STATUS_AND_RETURN_ON_FAIL(group_id, (int32_t) group_id,
                                         "Failed to create the %s group.\nThe file ID was %d\n", full_field_name,
@@ -233,7 +233,7 @@ int32_t initialize_hdf5_galaxy_files(const int filenr, struct save_info *save_in
         for(int32_t field_idx = 0; field_idx < NUM_OUTPUT_FIELDS; field_idx++) {
 
             // Then create each field inside.
-            snprintf(full_field_name, MAX_STRING_LEN - 1,"Snap_%d/%s", run_params->ListOutputSnaps[snap_idx], field_names[field_idx]);
+            snprintf(full_field_name, 2*MAX_STRING_LEN - 1,"Snap_%d/%s", run_params->ListOutputSnaps[snap_idx], field_names[field_idx]);
 
             /* fprintf(stderr, "Creating field '%s' with description '%s' and unit '%s'\n",
                field_names[field_idx], field_descriptions[field_idx], field_units[field_idx]); */
@@ -956,8 +956,8 @@ int32_t prepare_galaxy_for_hdf5_output(const struct GALAXY *g, struct save_info 
 
 /* Assumes 'snap_idx', 'field_idx' are set appropriately before invoking the macro */
 #define EXTEND_AND_WRITE_GALAXY_DATASET(field_name) {                   \
-    char full_field_name[MAX_STRING_LEN];                           \
-    snprintf(full_field_name, MAX_STRING_LEN - 1,"Snap_%d/%s", run_params->ListOutputSnaps[snap_idx], save_info->name_output_fields[field_idx]); \
+    char full_field_name[2*MAX_STRING_LEN];                           \
+    snprintf(full_field_name, 2*MAX_STRING_LEN - 1,"Snap_%d/%s", run_params->ListOutputSnaps[snap_idx], save_info->name_output_fields[field_idx]); \
     hid_t dataset_id = H5Dopen2(save_info->file_id, full_field_name, H5P_DEFAULT); \
     if(dataset_id < 0) {                                                \
         fprintf(stderr, "Could not access the " #field_name" dataset for output snapshot %d.\n", snap_idx); \

--- a/src/sage.c
+++ b/src/sage.c
@@ -515,7 +515,7 @@ int convert_trees_to_lhalo(const int ThisTask, const int NTasks, struct params *
         totnhalos += nhalos;
     }
 #ifdef USE_BUFFERED_WRITE
-    status = cleanup(&buf_io);
+    status = cleanup_buffered_io(&buf_io);
     if(status != EXIT_SUCCESS) {
         fprintf(stderr,"Error: Could not finalise the output file\n");
         return status;

--- a/src/sage.c
+++ b/src/sage.c
@@ -474,7 +474,6 @@ int convert_trees_to_lhalo(const int ThisTask, const int NTasks, struct params *
 #ifdef USE_BUFFERED_WRITE
     const size_t buffer_size = 4 * 1024 * 1024; //4 MB
     struct buffered_io buf_io;
-    // int setup_buffered_io(buffered_io *buf_io, const size_t buffer_size, int output_fd, const off_t start_offset) 
     int status = setup_buffered_io(&buf_io, buffer_size, fd, halo_data_start_offset);
     if(status != EXIT_SUCCESS) 
     {

--- a/src/sage.c
+++ b/src/sage.c
@@ -500,7 +500,7 @@ int convert_trees_to_lhalo(const int ThisTask, const int NTasks, struct params *
                 nhalos);
         const size_t numbytes = sizeof(struct halo_data)*nhalos;
 #ifdef USE_BUFFERED_WRITE
-        status = write_bufferd_io( &buf_io, Halo, numbytes);
+        status = write_buffered_io( &buf_io, Halo, numbytes);
         if(status < 0) {
             fprintf(stderr,"Error: Could not write (buffered). forestnr = %"PRId64" number of bytes = %zu\n", forestnr, numbytes);
             return status;

--- a/tests/test_sage.sh
+++ b/tests/test_sage.sh
@@ -144,7 +144,7 @@ if [[ $? == 0 ]]; then
         ((nfiles++))
 
         # First check if the correct and tests files are bitwise identical.
-        diff -q ${test_files[${nfiles}-1]} ${correct_files[${nfiles}-1]}
+        diff -q ${test_files[${nfiles}-1]} ${correct_files[${nfiles}-1]} 2>&1 1>/dev/null
         if [[ $? == 0 ]]; then
             ((npassed++))
             ((nbitwise++))


### PR DESCRIPTION
Many things got lumped into this 

- Adds the Gadget4 HDF5 mergertree format
- Solves #50 (which was caused by linux filesystem max. write size limit)
- Part-fixes #46 (fixed for Gadget4 format, but not the other TNG-hdf5 formats)
- Adds the ability to distribute files (i.e., load-balance) for the `lhalo-binary` and `lhalo-hdf5` formats (Issue #45)