### PR TITLE
Fixed issue of crash on TNG lhalo-hdf5 files

### DIFF
--- a/src/io/hdf5_read_utils.c
+++ b/src/io/hdf5_read_utils.c
@@ -167,7 +167,7 @@ int32_t fill_hdf5_metadata_names(struct HDF5_METADATA_NAMES *metadata_names, enu
     case lhalo_hdf5:
         snprintf(metadata_names->name_NTrees, MAX_STRING_LEN - 1, "NtreesPerFile"); // Total number of forests within the file.
         snprintf(metadata_names->name_totNHalos, MAX_STRING_LEN - 1, "NhalosPerFile"); // Total number of halos within the file.
-        snprintf(metadata_names->name_TreeNHalos, MAX_STRING_LEN - 1, "TreeNHalos"); // Number of halos per forest within the file.
+        snprintf(metadata_names->name_TreeNHalos, MAX_STRING_LEN - 1, "/Header/TreeNHalos"); // Number of halos per forest within the file.
         snprintf(metadata_names->name_ParticleMass, MAX_STRING_LEN - 1, "ParticleMass");//Particle mass for Dark matter in the sim
         snprintf(metadata_names->name_NumSimulationTreeFiles, MAX_STRING_LEN - 1, "NumberOfOutputFiles");//Particle mass for Dark matter in the sim
         return EXIT_SUCCESS;

--- a/src/io/read_tree_lhalo_hdf5.c
+++ b/src/io/read_tree_lhalo_hdf5.c
@@ -119,7 +119,10 @@ int setup_forests_io_lht_hdf5(struct forest_info *forests_info,
                      "Error: can't open file `%s'\n", filename);
 
             const int check_size = 1;
-            int32_t *buffer = NULL;
+            int32_t *buffer = malloc(sizeof(*buffer)*nforests_this_file);
+            XRETURN(buffer != NULL, MALLOC_FAILURE, "Error: Could not allocate memory for storing nhalos "\
+                                                    "per forest (%"PRId64" forests, with each element of size = %zu bytes)\n",
+                                                    nforests_this_file, sizeof(*buffer));
             int status = read_dataset(fd, metadata_names.name_TreeNHalos, -1, (void *) buffer, sizeof(*buffer), check_size);
             if(status < 0) {
                 return status;
@@ -127,7 +130,8 @@ int setup_forests_io_lht_hdf5(struct forest_info *forests_info,
             for(int64_t i=0;i<nforests_this_file;i++) {
                 nhalos_per_forest[i] = buffer[i];
             }
-            XRETURN( H5Fclose(fd) > 0, -1, "Error: Could not properly close the hdf5 file for filename = '%s'\n", filename);
+            free(buffer);
+            XRETURN( H5Fclose(fd) >= 0, -1, "Error: Could not properly close the hdf5 file for filename = '%s'\n", filename);
 
             nhalos_per_forest += nforests_this_file;
         }


### PR DESCRIPTION
There were two errors that were preventing `lhalo-hdf5` files from running - needed a `malloc`, and the dataset name needed to be from the root (i.e., `Header/TreeNHalos` rather than just `TreeNHalos`)

@aporrasval - once this PR is merged you should be able to run on the TNG sims