### PR TITLE
Fix for mergtime being too long

### DIFF
--- a/src/model_mergers.c
+++ b/src/model_mergers.c
@@ -34,7 +34,7 @@ double estimate_merging_time(const int sat_halo, const int mother_halo, const in
         mergtime = -1.0;
     }
 
-    if (mergtime > 999.0)
+    if (mergtime >= 999.0)
     {
         mergtime = 998.0;
         // implementing time ceiling since some objects have merge times longer than universe age when using

--- a/src/model_mergers.c
+++ b/src/model_mergers.c
@@ -34,6 +34,13 @@ double estimate_merging_time(const int sat_halo, const int mother_halo, const in
         mergtime = -1.0;
     }
 
+    if (mergtime > 999.0)
+    {
+        mergtime = 998.0;
+        // implementing time ceiling since some objects have merge times longer than universe age when using
+        // TNG50 merger trees because of lower simulation particle mass 
+    }
+
     return mergtime;
 
 }


### PR DESCRIPTION
Added ceiling to merge time in estimate_merging_time in model_mergers.c. When running SAGE on TNG50 trees, some galaxies have merge times greater than the universe age which causes the run to fail.